### PR TITLE
feat: double-click preview card to open editor

### DIFF
--- a/Screendrop/PreviewCardView.swift
+++ b/Screendrop/PreviewCardView.swift
@@ -100,6 +100,15 @@ struct PreviewCardView: View {
                     onHoverChanged(status)
                 }
             }
+            .simultaneousGesture(
+                TapGesture(count: 2).onEnded {
+                    if item.kind == .video {
+                        onEditVideo()
+                    } else {
+                        onAnnotate()
+                    }
+                }
+            )
             .onAppear {
                 isPresented = false
 


### PR DESCRIPTION
## Summary

Double-clicking anywhere on the preview card (outside of the action buttons) now opens the editor — matching the same behavior in CleanShot X.

## Changes

- **`PreviewCardView.swift`**: Added a `.simultaneousGesture(TapGesture(count: 2))` modifier to the card. Uses `simultaneousGesture` to avoid conflicting with the existing drag gesture or button taps.
  - Images → opens the annotation editor
  - Videos → opens the video editor

## Testing

1. Take a screenshot or recording
2. Hover over the preview card in the bottom-right corner
3. Double-click anywhere on the card (not on a corner button)
4. The editor should open