### PR TITLE
Double-click to annotate + decoupled silent save button

### DIFF
--- a/Screendrop/ScreendropPreferences.swift
+++ b/Screendrop/ScreendropPreferences.swift
@@ -11,6 +11,7 @@ import UniformTypeIdentifiers
 
 enum ScreendropPreferences {
     static let autoSaveKey = "autoSaveScreenshots"
+    static let saveButtonUsesFolderKey = "saveButtonUsesConfiguredFolder"
     static let autoCopyKey = "autoCopyScreenshotsToClipboard"
     static let autoCompressKey = "autoCompressScreenshots"
     static let exportFormatKey = "exportFormat"
@@ -40,6 +41,13 @@ enum ScreendropPreferences {
     
     static var autoSave: Bool {
         UserDefaults.standard.bool(forKey: autoSaveKey)
+    }
+
+    static var saveButtonUsesConfiguredFolder: Bool {
+        if UserDefaults.standard.object(forKey: saveButtonUsesFolderKey) == nil {
+            return autoSave
+        }
+        return UserDefaults.standard.bool(forKey: saveButtonUsesFolderKey)
     }
     
     static var autoCopy: Bool {

--- a/Screendrop/ScreenshotPreviewStack.swift
+++ b/Screendrop/ScreenshotPreviewStack.swift
@@ -396,7 +396,7 @@ final class ScreenshotPreviewStack {
         guard let index = items.firstIndex(where: { $0.id == id }) else { return }
         let kind = items[index].kind
 
-        if ScreendropPreferences.autoSave {
+        if ScreendropPreferences.saveButtonUsesConfiguredFolder {
             if items[index].autoSavedURL == nil {
                 items[index].autoSavedURL = kind == .video
                     ? saveVideoToDefaultLocation(from: items[index].url)

--- a/Screendrop/ScreenshotPreviewStack.swift
+++ b/Screendrop/ScreenshotPreviewStack.swift
@@ -427,6 +427,7 @@ final class ScreenshotPreviewStack {
                 if let index = self?.items.firstIndex(where: { $0.id == id }) {
                     self?.items[index].autoSavedURL = destURL
                 }
+                self?.dismiss(id: id)
             } catch {
                 print("Failed to save preview: \(error)")
             }

--- a/Screendrop/SettingsGeneralPane.swift
+++ b/Screendrop/SettingsGeneralPane.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct GeneralSettingsPane: View {
     @AppStorage(ScreendropPreferences.exportDirectoryPathKey) private var exportDirectoryPath = ""
+    @AppStorage(ScreendropPreferences.saveButtonUsesFolderKey) private var saveButtonUsesFolder = false
     @AppStorage(ScreendropPreferences.playSoundsKey) private var playSounds = true
     @AppStorage(ScreendropPreferences.showMenuBarIconKey) private var showMenuBarIcon = true
     @State private var launchAtLoginStatus = LaunchAtLoginController.status
@@ -18,6 +19,13 @@ struct GeneralSettingsPane: View {
         Binding(
             get: { launchAtLoginStatus.isEnabled },
             set: updateLaunchAtLogin
+        )
+    }
+
+    private var saveButtonUsesFolderBinding: Binding<Bool> {
+        Binding(
+            get: { _ = saveButtonUsesFolder; return ScreendropPreferences.saveButtonUsesConfiguredFolder },
+            set: { saveButtonUsesFolder = $0 }
         )
     }
 
@@ -50,6 +58,16 @@ struct GeneralSettingsPane: View {
                     .controlSize(.small)
                     .disabled(exportDirectoryPath.isEmpty)
                 }
+
+                Toggle(isOn: saveButtonUsesFolderBinding) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Save without choosing a location")
+                        Text("When you click Save, write straight to the export folder instead of asking where to put it.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
             }
 
             Section("System") {


### PR DESCRIPTION
## Overview

Two independent UX improvements to the preview card:

1. **Double-click to open annotation editor** — double-clicking a preview card now opens the annotation editor directly, without going through the action menu.
2. **Decoupled silent save button** — the preview card's Save button now has its own setting for whether to write straight to the configured export folder, independent of the auto-save-on-capture setting. Also fixes a bug where the preview card didn't dismiss after a successful manual save.

---

## 1. Double-click to open annotation editor

Adds a double-click gesture to preview cards that jumps straight into the annotation editor, matching the muscle memory most users have from other tools.

**Changed:** `PreviewCardView.swift`

---

## 2. Decoupled Save button + dismiss fix

### Problem

Previously, a single boolean (`autoSave` / "Save to folder" in After Capture settings) controlled two distinct behaviors:

- **Auto-save on capture** — captures land in the export folder immediately with no interaction.
- **Preview card Save button** — whether clicking Save writes silently to the folder or opens an `NSSavePanel`.

This made a natural combination impossible: _"don't auto-save everything on capture (I want to review first), but when I do click Save, just put it in my configured folder without prompting."_

A second, unrelated bug: when the Save panel _was_ shown and the user successfully saved a file, the preview card didn't dismiss — it stayed on screen.

### Changes

**New preference — `saveButtonUsesConfiguredFolder`**
- Key: `saveButtonUsesConfiguredFolder` in `UserDefaults`
- When the key is unset (new installs / existing users who haven't touched it), it inherits the current `autoSave` value — **zero behavior change for existing users**.
- The two settings become fully independent the moment the new toggle is changed.

**Preview card Save button** (`ScreenshotPreviewStack.swift`)
- Gates the silent-save path on the new `saveButtonUsesConfiguredFolder` accessor instead of `autoSave`.
- `republishLatestVersion` (the post-annotation re-save path) continues to use `autoSave` — it's about keeping an already-auto-saved file in sync with edits, which is genuinely the capture setting.

**Settings UI** (`SettingsGeneralPane.swift`)
- New toggle added to **General → Save Location**, directly beneath the export folder picker:
  > **Save without choosing a location**
  > When you click Save, write straight to the export folder instead of asking where to put it.
- Uses a computed `Binding` so the toggle's displayed state reflects the effective (inherited) value before the user has explicitly set it.

**Dismiss after manual save** (`ScreenshotPreviewStack.swift`)
- In the `NSSavePanel` completion handler, `dismiss(id:)` is now called after a successful save — matching the silent-save path.
- Cancel and write errors leave the preview up so the capture is not lost.

### Files changed

| File | Change |
|------|--------|
| `Screendrop/ScreendropPreferences.swift` | New key constant + `saveButtonUsesConfiguredFolder` accessor |
| `Screendrop/ScreenshotPreviewStack.swift` | Gate swap + dismiss-on-save fix |
| `Screendrop/SettingsGeneralPane.swift` | New toggle in Save Location section |

### Behavior matrix after this change

| Auto-save on capture | Save button uses folder | Take screenshot | Click Save |
|---|---|---|---|
| OFF | OFF | Nothing auto-saved | Panel appears; cancel keeps preview; success dismisses it |
| OFF | ON | Nothing auto-saved | Silent write to export folder; preview dismisses |
| ON | OFF | Auto-saved on capture | Panel appears (independent of capture setting) |
| ON | ON | Auto-saved on capture | Silent write to export folder; preview dismisses |

### Out of scope

The annotation editor's "Save As" button always shows a panel regardless of either setting — this was an explicit decision to keep that flow unchanged.