### PR TITLE
Adjustable area selection before screen recording

### DIFF
--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -75,7 +75,6 @@ final class RecordingAreaSelectionPresenter {
         installKeyMonitor()
         panel.makeKeyAndOrderFront(nil)
         panel.orderFrontRegardless()
-        selectionView.beginSelectionCursorSession()
     }
 
     func cancel() {
@@ -87,7 +86,6 @@ final class RecordingAreaSelectionPresenter {
         self.completion = nil
         display = nil
         removeKeyMonitor()
-        (panel?.contentView as? RecordingAreaSelectionView)?.endSelectionCursorSession()
         panel?.orderOut(nil)
         panel = nil
         completion?(rect)
@@ -121,10 +119,28 @@ private final class RecordingAreaSelectionView: NSView {
     var onSelect: ((CGRect) -> Void)?
     var onCancel: (() -> Void)?
 
-    private var startPoint: CGPoint?
-    private var currentPoint: CGPoint?
+    private enum DragMode {
+        case none
+        case drawing
+        case moving
+        case resizing(Handle)
+    }
+
+    private enum Handle: CaseIterable {
+        case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
+    }
+
     private let pixelScale: CGSize
-    private var didPushSelectionCursor = false
+    private let minimumSize: CGFloat = 16
+    private let handleLength: CGFloat = 10
+    private let handleHitPadding: CGFloat = 6
+
+    private var selection: CGRect?
+    private var drawStart: CGPoint?
+    private var drawCurrent: CGPoint?
+    private var dragMode: DragMode = .none
+    private var moveOffset: CGSize = .zero
+    private var resizeAnchor: CGRect = .zero
 
     override var acceptsFirstResponder: Bool {
         true
@@ -140,95 +156,298 @@ private final class RecordingAreaSelectionView: NSView {
         nil
     }
 
-    deinit {
-        endSelectionCursorSession()
+    // MARK: - Active rect
+
+    private var draftRect: CGRect? {
+        guard let drawStart, let drawCurrent else { return nil }
+
+        return CGRect(
+            x: min(drawStart.x, drawCurrent.x),
+            y: min(drawStart.y, drawCurrent.y),
+            width: abs(drawStart.x - drawCurrent.x),
+            height: abs(drawStart.y - drawCurrent.y)
+        )
     }
+
+    private var isDrawing: Bool {
+        if case .drawing = dragMode { return true }
+        return false
+    }
+
+    private var activeRect: CGRect? {
+        isDrawing ? draftRect : selection
+    }
+
+    // MARK: - Drawing
 
     override func draw(_ dirtyRect: NSRect) {
         NSColor.black.withAlphaComponent(0.28).setFill()
         bounds.fill()
 
-        guard let selectionRect else { return }
+        if let rect = activeRect {
+            NSColor.clear.setFill()
+            rect.fill(using: .clear)
 
-        NSColor.clear.setFill()
-        selectionRect.fill(using: .clear)
+            NSColor.white.withAlphaComponent(0.96).setStroke()
+            let border = NSBezierPath(roundedRect: rect, xRadius: 4, yRadius: 4)
+            border.lineWidth = 2
+            border.stroke()
 
-        NSColor.white.withAlphaComponent(0.96).setStroke()
-        let border = NSBezierPath(roundedRect: selectionRect, xRadius: 4, yRadius: 4)
-        border.lineWidth = 2
-        border.stroke()
+            drawSelectionSize(for: rect)
 
-        drawSelectionSize(for: selectionRect)
+            if !isDrawing, selection != nil {
+                drawHandles(for: rect)
+            }
+        }
+
+        if !isDrawing {
+            drawHint()
+        }
     }
 
-    override func resetCursorRects() {
-        addCursorRect(bounds, cursor: .annotationPlus)
+    private func drawHint() {
+        let text = selection == nil
+            ? "Drag to select an area    Esc to cancel"
+            : "Return to record    Drag to adjust    Esc to cancel"
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: NSColor.white
+        ]
+        let attributedHint = NSAttributedString(string: text, attributes: attributes)
+        let textSize = attributedHint.size()
+        let padding = CGSize(width: 14, height: 9)
+        let badgeSize = CGSize(width: textSize.width + padding.width * 2, height: textSize.height + padding.height * 2)
+        let badgeRect = CGRect(
+            x: bounds.midX - badgeSize.width / 2,
+            y: bounds.maxY - badgeSize.height - 28,
+            width: badgeSize.width,
+            height: badgeSize.height
+        )
+
+        NSColor.black.withAlphaComponent(0.62).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 9, yRadius: 9).fill()
+
+        attributedHint.draw(
+            at: CGPoint(
+                x: badgeRect.minX + padding.width,
+                y: badgeRect.minY + padding.height
+            )
+        )
     }
+
+    private func drawHandles(for rect: CGRect) {
+        for handle in Handle.allCases {
+            let center = handlePoint(handle, in: rect)
+            let square = CGRect(
+                x: center.x - handleLength / 2,
+                y: center.y - handleLength / 2,
+                width: handleLength,
+                height: handleLength
+            )
+            let path = NSBezierPath(roundedRect: square, xRadius: 2, yRadius: 2)
+            NSColor.white.setFill()
+            path.fill()
+            NSColor.black.withAlphaComponent(0.55).setStroke()
+            path.lineWidth = 1
+            path.stroke()
+        }
+    }
+
+    // MARK: - Mouse
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if let selection {
+            if event.clickCount >= 2, selection.contains(point) {
+                commitSelection()
+                return
+            }
+            if let handle = handle(at: point, in: selection) {
+                dragMode = .resizing(handle)
+                resizeAnchor = selection
+                return
+            }
+            if selection.contains(point) {
+                dragMode = .moving
+                moveOffset = CGSize(width: point.x - selection.minX, height: point.y - selection.minY)
+                NSCursor.closedHand.set()
+                return
+            }
+        }
+
+        dragMode = .drawing
+        selection = nil
+        drawStart = point
+        drawCurrent = point
+        needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        switch dragMode {
+        case .drawing:
+            drawCurrent = point
+        case .moving:
+            if let current = selection {
+                var moved = current
+                moved.origin = CGPoint(
+                    x: point.x - moveOffset.width,
+                    y: point.y - moveOffset.height
+                )
+                selection = clampToBounds(moved)
+            }
+        case .resizing(let handle):
+            selection = resizedRect(anchor: resizeAnchor, handle: handle, to: point)
+        case .none:
+            break
+        }
+
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if case .drawing = dragMode {
+            drawCurrent = point
+            if let rect = draftRect, rect.width >= minimumSize, rect.height >= minimumSize {
+                selection = clampToBounds(rect)
+            } else {
+                selection = nil
+            }
+            drawStart = nil
+            drawCurrent = nil
+        }
+
+        dragMode = .none
+        needsDisplay = true
+        window?.invalidateCursorRects(for: self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 53:            // Escape
+            onCancel?()
+        case 36, 76:        // Return / keypad Enter
+            commitSelection()
+        default:
+            super.keyDown(with: event)
+        }
+    }
+
+    private func commitSelection() {
+        guard let selection else { return }
+        onSelect?(selection)
+    }
+
+    // MARK: - Geometry
+
+    private func handlePoint(_ handle: Handle, in rect: CGRect) -> CGPoint {
+        switch handle {
+        case .topLeft:     return CGPoint(x: rect.minX, y: rect.maxY)
+        case .top:         return CGPoint(x: rect.midX, y: rect.maxY)
+        case .topRight:    return CGPoint(x: rect.maxX, y: rect.maxY)
+        case .right:       return CGPoint(x: rect.maxX, y: rect.midY)
+        case .bottomRight: return CGPoint(x: rect.maxX, y: rect.minY)
+        case .bottom:      return CGPoint(x: rect.midX, y: rect.minY)
+        case .bottomLeft:  return CGPoint(x: rect.minX, y: rect.minY)
+        case .left:        return CGPoint(x: rect.minX, y: rect.midY)
+        }
+    }
+
+    private func handleHitRect(_ handle: Handle, in rect: CGRect) -> CGRect {
+        let center = handlePoint(handle, in: rect)
+        let reach = handleLength / 2 + handleHitPadding
+        return CGRect(
+            x: center.x - reach,
+            y: center.y - reach,
+            width: reach * 2,
+            height: reach * 2
+        )
+    }
+
+    private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
+        Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
+    }
+
+    private func resizedRect(anchor: CGRect, handle: Handle, to rawPoint: CGPoint) -> CGRect {
+        var minX = anchor.minX
+        var maxX = anchor.maxX
+        var minY = anchor.minY
+        var maxY = anchor.maxY
+
+        let px = max(bounds.minX, min(rawPoint.x, bounds.maxX))
+        let py = max(bounds.minY, min(rawPoint.y, bounds.maxY))
+
+        switch handle {
+        case .left, .topLeft, .bottomLeft:
+            minX = min(px, anchor.maxX - minimumSize)
+        case .right, .topRight, .bottomRight:
+            maxX = max(px, anchor.minX + minimumSize)
+        default:
+            break
+        }
+
+        switch handle {
+        case .bottom, .bottomLeft, .bottomRight:
+            minY = min(py, anchor.maxY - minimumSize)
+        case .top, .topLeft, .topRight:
+            maxY = max(py, anchor.minY + minimumSize)
+        default:
+            break
+        }
+
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    private func clampToBounds(_ rect: CGRect) -> CGRect {
+        var result = rect
+        result.size.width = min(result.size.width, bounds.width)
+        result.size.height = min(result.size.height, bounds.height)
+        result.origin.x = max(bounds.minX, min(result.origin.x, bounds.maxX - result.width))
+        result.origin.y = max(bounds.minY, min(result.origin.y, bounds.maxY - result.height))
+        return result
+    }
+
+    // MARK: - Cursor
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.invalidateCursorRects(for: self)
         if window != nil {
-            beginSelectionCursorSession()
-        } else {
-            endSelectionCursorSession()
-        }
-    }
-
-    override func cursorUpdate(with event: NSEvent) {
-        beginSelectionCursorSession()
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        startPoint = point
-        currentPoint = point
-        needsDisplay = true
-    }
-
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        beginSelectionCursorSession()
-        return true
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-        currentPoint = convert(event.locationInWindow, from: nil)
-        needsDisplay = true
-    }
-
-    override func mouseUp(with event: NSEvent) {
-        currentPoint = convert(event.locationInWindow, from: nil)
-        guard let rect = selectionRect, rect.width >= 16, rect.height >= 16 else {
-            onCancel?()
-            return
-        }
-
-        onSelect?(rect)
-    }
-
-    override func keyDown(with event: NSEvent) {
-        if event.keyCode == 53 {
-            onCancel?()
-        } else {
-            super.keyDown(with: event)
-        }
-    }
-
-    func beginSelectionCursorSession() {
-        if didPushSelectionCursor {
             NSCursor.annotationPlus.set()
-        } else {
-            NSCursor.annotationPlus.push()
-            didPushSelectionCursor = true
         }
     }
 
-    func endSelectionCursorSession() {
-        guard didPushSelectionCursor else { return }
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .annotationPlus)
 
-        NSCursor.pop()
-        didPushSelectionCursor = false
+        guard let selection, !isDrawing else { return }
+
+        addCursorRect(selection, cursor: .openHand)
+        for handle in Handle.allCases {
+            addCursorRect(handleHitRect(handle, in: selection), cursor: cursor(for: handle))
+        }
     }
+
+    private func cursor(for handle: Handle) -> NSCursor {
+        switch handle {
+        case .left, .right:
+            return .resizeLeftRight
+        case .top, .bottom:
+            return .resizeUpDown
+        case .topLeft, .topRight, .bottomLeft, .bottomRight:
+            return .crosshair
+        }
+    }
+
+    // MARK: - Size badge
 
     private func drawSelectionSize(for rect: CGRect) {
         let pixelWidth = Int((rect.width * pixelScale.width).rounded())
@@ -266,17 +485,6 @@ private final class RecordingAreaSelectionView: NSView {
         return CGPoint(
             x: min(max(rect.minX, bounds.minX + 8), bounds.maxX - size.width - 8),
             y: max(fallbackY, bounds.minY + 8)
-        )
-    }
-
-    private var selectionRect: CGRect? {
-        guard let startPoint, let currentPoint else { return nil }
-
-        return CGRect(
-            x: min(startPoint.x, currentPoint.x),
-            y: min(startPoint.y, currentPoint.y),
-            width: abs(startPoint.x - currentPoint.x),
-            height: abs(startPoint.y - currentPoint.y)
         )
     }
 }


### PR DESCRIPTION
## What

When recording a screen **Area**, the selection rectangle is now adjustable before recording starts. Previously, releasing the drag started recording immediately. Now you can:

- Drag to draw the area
- Resize it with 8 handles (corners + edge midpoints)
- Drag the body to reposition it
- Press **Return** (or double-click inside the selection) to start recording
- Press **Esc** to cancel

A small hint banner communicates the controls, and the cursor reflects move vs. resize.

## Why

Nailing a precise capture region in one uninterrupted drag is hard. Letting the user nudge the region before recording avoids re-recording over a slightly-off selection. This is intended as the first, self-contained step toward a fuller recording setup HUD (capture mode + aspect-ratio presets); each piece is kept as a small, independently reviewable change.

## Behavior change

Area recording no longer starts on mouse-up — it waits for Return or a double-click. Full Screen and Window recording are unchanged.

## Scope

- Only `RecordingAreaSelectionPresenter.swift` is touched.
- No aspect-ratio presets or floating toolbar in this PR (planned follow-ups).
- The committed rectangle flows through the existing `ScreenRecordingSource.area` path, so the capture pipeline itself is unchanged. The forced crosshair cursor session was replaced with standard `resetCursorRects`.

## Testing

- `xcodebuild -scheme Screendrop -configuration Debug -destination 'platform=macOS'` builds successfully.
- Manual: trigger area recording → drag a region → resize via handles → reposition → press Return to record and confirm the output matches the region; press Esc to cancel.

## Demo

_Screen recording to be added._