### PR TITLE
Add aspect-ratio presets and setup toolbar to area recording

### DIFF
--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -343,8 +343,16 @@ private final class RecordingAreaSelectionView: NSView {
         }
     }
 
+    /// When an aspect preset is active only the 4 corner handles are shown;
+    /// edge-only handles (top/bottom/left/right) would break the ratio lock.
+    private var activeHandles: [Handle] {
+        aspect.locksAspect
+            ? [.topLeft, .topRight, .bottomLeft, .bottomRight]
+            : Handle.allCases
+    }
+
     private func drawHandles(for rect: CGRect) {
-        for handle in Handle.allCases {
+        for handle in activeHandles {
             let center = handlePoint(handle, in: rect)
             let sq = CGRect(
                 x: center.x - handleLength / 2,
@@ -503,7 +511,7 @@ private final class RecordingAreaSelectionView: NSView {
     }
 
     private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
-        Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
+        activeHandles.first { handleHitRect($0, in: rect).contains(point) }
     }
 
     private func resizedRect(anchor: CGRect, handle: Handle, to raw: CGPoint) -> CGRect {
@@ -617,7 +625,7 @@ private final class RecordingAreaSelectionView: NSView {
         addCursorRect(bounds, cursor: .annotationPlus)
         guard let selection, !isDrawing else { return }
         addCursorRect(selection, cursor: .openHand)
-        for handle in Handle.allCases {
+        for handle in activeHandles {
             addCursorRect(handleHitRect(handle, in: selection), cursor: cursorFor(handle))
         }
     }

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -7,12 +7,18 @@
 
 import AppKit
 import ScreenCaptureKit
+import SwiftUI
+
+// MARK: - Presenter
 
 @MainActor
 final class RecordingAreaSelectionPresenter {
     static let shared = RecordingAreaSelectionPresenter()
 
     private var panel: NSPanel?
+    private var toolbarPanel: NSPanel?
+    private var selectionView: RecordingAreaSelectionView?
+    private var model: RecordingSetupModel?
     private var completion: ((CGRect?) -> Void)?
     private var display: SCDisplay?
     private var keyMonitor: Any?
@@ -27,75 +33,147 @@ final class RecordingAreaSelectionPresenter {
             return
         }
 
-        self.display = display
+        self.display   = display
         self.completion = completion
 
-        let panel = RecordingAreaSelectionPanel(
-            contentRect: screen.frame,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
+        let pixelScale = CGSize(
+            width:  CGFloat(display.width)  / max(screen.frame.width,  1),
+            height: CGFloat(display.height) / max(screen.frame.height, 1)
         )
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.hasShadow = false
-        panel.level = .screenSaver
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        panel.isReleasedWhenClosed = false
-        panel.acceptsMouseMovedEvents = true
 
-        let selectionView = RecordingAreaSelectionView(
-            frame: CGRect(origin: .zero, size: screen.frame.size),
-            pixelScale: CGSize(
-                width: CGFloat(display.width) / max(screen.frame.width, 1),
-                height: CGFloat(display.height) / max(screen.frame.height, 1)
-            )
+        // Shared observable model
+        let setupModel = RecordingSetupModel(pixelScale: pixelScale)
+        self.model = setupModel
+
+        // ── Overlay panel ──────────────────────────────────────────────────
+        let overlayPanel = RecordingAreaSelectionPanel(
+            contentRect: screen.frame,
+            styleMask:   [.borderless, .nonactivatingPanel],
+            backing:     .buffered,
+            defer:       false
         )
-        selectionView.onCancel = { [weak self] in
+        overlayPanel.backgroundColor          = .clear
+        overlayPanel.isOpaque                 = false
+        overlayPanel.hasShadow                = false
+        overlayPanel.level                    = .screenSaver
+        overlayPanel.collectionBehavior       = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        overlayPanel.isReleasedWhenClosed     = false
+        overlayPanel.acceptsMouseMovedEvents  = true
+
+        let selView = RecordingAreaSelectionView(
+            frame:      CGRect(origin: .zero, size: screen.frame.size),
+            pixelScale: pixelScale
+        )
+
+        // Cancel from overlay
+        selView.onCancel = { [weak self] in
             self?.finish(rect: nil)
         }
-        selectionView.onSelect = { [weak self, weak panel] localRect in
-            guard let self, let panel else {
-                self?.finish(rect: nil)
-                return
-            }
 
-            let globalRect = CGRect(
-                x: panel.frame.minX + localRect.minX,
-                y: panel.frame.minY + localRect.minY,
-                width: localRect.width,
-                height: localRect.height
-            )
-            self.finish(rect: globalRect)
+        // Confirm from Return key or double-click — passes local rect directly
+        selView.onSelect = { [weak self, weak overlayPanel] localRect in
+            guard let self, let overlayPanel else { self?.finish(rect: nil); return }
+            self.finish(rect: self.toGlobal(localRect, panel: overlayPanel))
         }
 
-        panel.contentView = selectionView
-        panel.makeFirstResponder(selectionView)
-        self.panel = panel
+        // Keep model.selection in sync for the toolbar's size readout + Start enable state
+        selView.onSelectionChanged = { [weak setupModel] rect in
+            setupModel?.selection = rect
+        }
+
+        overlayPanel.contentView        = selView
+        overlayPanel.makeFirstResponder(selView)
+        self.panel         = overlayPanel
+        self.selectionView = selView
+
+        // ── Toolbar panel ──────────────────────────────────────────────────
+        toolbarPanel = makeToolbarPanel(screen: screen, model: setupModel)
+
         installKeyMonitor()
-        panel.makeKeyAndOrderFront(nil)
-        panel.orderFrontRegardless()
+        overlayPanel.makeKeyAndOrderFront(nil)
+        overlayPanel.orderFrontRegardless()
+        toolbarPanel?.orderFrontRegardless()
     }
 
     func cancel() {
         finish(rect: nil)
     }
 
+    // MARK: Private
+
     private func finish(rect: CGRect?) {
-        let completion = completion
-        self.completion = nil
-        display = nil
+        let completion  = completion
+        self.completion  = nil
+        display          = nil
+        model            = nil
+        selectionView    = nil
         removeKeyMonitor()
+        toolbarPanel?.orderOut(nil)
+        toolbarPanel = nil
         panel?.orderOut(nil)
         panel = nil
         completion?(rect)
     }
 
+    /// Convert a panel-local rect to global screen coordinates.
+    private func toGlobal(_ localRect: CGRect, panel: NSPanel) -> CGRect {
+        CGRect(
+            x:      panel.frame.minX + localRect.minX,
+            y:      panel.frame.minY + localRect.minY,
+            width:  localRect.width,
+            height: localRect.height
+        )
+    }
+
+    /// Called by the toolbar's Start button — reads the committed selection
+    /// from the model and converts it to global coordinates.
+    private func finishWithModelSelection() {
+        guard let model, let panel else { return }
+        guard let localRect = model.selection   else { return }
+        finish(rect: toGlobal(localRect, panel: panel))
+    }
+
+    private func makeToolbarPanel(screen: NSScreen, model: RecordingSetupModel) -> NSPanel {
+        let toolbarView = RecordingSetupToolbarView(
+            model:          model,
+            onStart:        { [weak self] in self?.finishWithModelSelection() },
+            onCancel:       { [weak self] in self?.cancel() },
+            onAspectChange: { [weak self] aspect in
+                self?.selectionView?.applyAspect(aspect)
+            }
+        )
+
+        let hosting     = NSHostingView(rootView: toolbarView)
+        let idealSize   = hosting.fittingSize
+        let panelWidth  = max(idealSize.width,  480)
+        let panelHeight = idealSize.height > 0 ? idealSize.height : 72
+
+        let panel = NSPanel(
+            contentRect: CGRect(
+                x: screen.frame.midX - panelWidth / 2,
+                y: screen.frame.minY + 32,
+                width:  panelWidth,
+                height: panelHeight
+            ),
+            styleMask:   [.borderless, .nonactivatingPanel],
+            backing:     .buffered,
+            defer:       false
+        )
+        panel.backgroundColor          = .clear
+        panel.isOpaque                 = false
+        panel.hasShadow                = false
+        panel.level                    = .screenSaver
+        panel.collectionBehavior       = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.isReleasedWhenClosed     = false
+        panel.sharingType              = .none   // excluded from recordings
+        panel.contentView              = hosting
+        return panel
+    }
+
     private func installKeyMonitor() {
         removeKeyMonitor()
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.keyCode == 53 else { return event }
-
+            guard event.keyCode == 53 else { return event }   // Esc
             self?.finish(rect: nil)
             return nil
         }
@@ -109,15 +187,26 @@ final class RecordingAreaSelectionPresenter {
     }
 }
 
+// MARK: - Panel subclass
+
 private final class RecordingAreaSelectionPanel: NSPanel {
-    override var canBecomeKey: Bool {
-        true
-    }
+    override var canBecomeKey: Bool { true }
 }
 
+// MARK: - Selection view
+
 private final class RecordingAreaSelectionView: NSView {
-    var onSelect: ((CGRect) -> Void)?
-    var onCancel: (() -> Void)?
+
+    // Callbacks
+    var onSelect:           ((CGRect) -> Void)?
+    var onCancel:           (() -> Void)?
+    var onSelectionChanged: ((CGRect?) -> Void)?
+
+    /// Active aspect constraint.  Updated by the presenter when the user picks
+    /// a chip; the view re-fits the existing selection and locks future drags.
+    var aspect: CropAspectRatio = .freeform
+
+    // MARK: Internal state
 
     private enum DragMode {
         case none
@@ -130,21 +219,19 @@ private final class RecordingAreaSelectionView: NSView {
         case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
     }
 
-    private let pixelScale: CGSize
-    private let minimumSize: CGFloat = 16
-    private let handleLength: CGFloat = 10
-    private let handleHitPadding: CGFloat = 6
+    private let pixelScale:     CGSize
+    private let minimumSize:    CGFloat = 16
+    private let handleLength:   CGFloat = 10
+    private let handleHitPad:   CGFloat = 6
 
-    private var selection: CGRect?
-    private var drawStart: CGPoint?
-    private var drawCurrent: CGPoint?
-    private var dragMode: DragMode = .none
-    private var moveOffset: CGSize = .zero
-    private var resizeAnchor: CGRect = .zero
+    private var selection:    CGRect?
+    private var drawStart:    CGPoint?
+    private var drawCurrent:  CGPoint?
+    private var dragMode:     DragMode = .none
+    private var moveOffset:   CGSize   = .zero
+    private var resizeAnchor: CGRect   = .zero
 
-    override var acceptsFirstResponder: Bool {
-        true
-    }
+    override var acceptsFirstResponder: Bool { true }
 
     init(frame frameRect: NSRect, pixelScale: CGSize) {
         self.pixelScale = pixelScale
@@ -152,31 +239,75 @@ private final class RecordingAreaSelectionView: NSView {
         wantsLayer = true
     }
 
-    required init?(coder: NSCoder) {
-        nil
+    required init?(coder: NSCoder) { nil }
+
+    // MARK: - Aspect
+
+    /// Apply a new aspect constraint and re-fit the existing selection (if any).
+    func applyAspect(_ newAspect: CropAspectRatio) {
+        aspect = newAspect
+        guard let current = selection,
+              let ratio   = newAspect.pixelRatio(imageSize: .zero) else {
+            needsDisplay = true
+            return
+        }
+        let cw = current.width
+        let ch = current.height
+        var w: CGFloat
+        var h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+        // Clamp to screen bounds
+        if w > bounds.width  { w = bounds.width;  h = w / ratio }
+        if h > bounds.height { h = bounds.height; w = h * ratio }
+        selection = CGRect(
+            x: min(max(current.midX - w / 2, bounds.minX), bounds.maxX - w),
+            y: min(max(current.midY - h / 2, bounds.minY), bounds.maxY - h),
+            width: w, height: h
+        )
+        onSelectionChanged?(selection)
+        needsDisplay = true
+        window?.invalidateCursorRects(for: self)
     }
 
     // MARK: - Active rect
-
-    private var draftRect: CGRect? {
-        guard let drawStart, let drawCurrent else { return nil }
-
-        return CGRect(
-            x: min(drawStart.x, drawCurrent.x),
-            y: min(drawStart.y, drawCurrent.y),
-            width: abs(drawStart.x - drawCurrent.x),
-            height: abs(drawStart.y - drawCurrent.y)
-        )
-    }
 
     private var isDrawing: Bool {
         if case .drawing = dragMode { return true }
         return false
     }
 
-    private var activeRect: CGRect? {
-        isDrawing ? draftRect : selection
+    private var draftRect: CGRect? {
+        guard let drawStart, let drawCurrent else { return nil }
+        let dx = drawCurrent.x - drawStart.x
+        let dy = drawCurrent.y - drawStart.y
+
+        guard let ratio = aspect.pixelRatio(imageSize: .zero) else {
+            // Freeform
+            return CGRect(
+                x: min(drawStart.x, drawCurrent.x),
+                y: min(drawStart.y, drawCurrent.y),
+                width:  abs(dx),
+                height: abs(dy)
+            )
+        }
+
+        // Aspect-locked: shrink the over-constrained dimension so the rect
+        // always fits within the drag extent.
+        let cw = abs(dx), ch = abs(dy)
+        let w: CGFloat
+        let h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+
+        return CGRect(
+            x: dx >= 0 ? drawStart.x : drawStart.x - w,
+            y: dy >= 0 ? drawStart.y : drawStart.y - h,
+            width: w, height: h
+        )
     }
+
+    private var activeRect: CGRect? { isDrawing ? draftRect : selection }
 
     // MARK: - Drawing
 
@@ -200,51 +331,22 @@ private final class RecordingAreaSelectionView: NSView {
             }
         }
 
-        if !isDrawing {
-            drawHint()
+        // Hint: only before the first selection; toolbar handles the rest.
+        if !isDrawing, selection == nil {
+            drawHint("Drag to select an area")
         }
-    }
-
-    private func drawHint() {
-        let text = selection == nil
-            ? "Drag to select an area    Esc to cancel"
-            : "Return to record    Drag to adjust    Esc to cancel"
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 13, weight: .medium),
-            .foregroundColor: NSColor.white
-        ]
-        let attributedHint = NSAttributedString(string: text, attributes: attributes)
-        let textSize = attributedHint.size()
-        let padding = CGSize(width: 14, height: 9)
-        let badgeSize = CGSize(width: textSize.width + padding.width * 2, height: textSize.height + padding.height * 2)
-        let badgeRect = CGRect(
-            x: bounds.midX - badgeSize.width / 2,
-            y: bounds.maxY - badgeSize.height - 28,
-            width: badgeSize.width,
-            height: badgeSize.height
-        )
-
-        NSColor.black.withAlphaComponent(0.62).setFill()
-        NSBezierPath(roundedRect: badgeRect, xRadius: 9, yRadius: 9).fill()
-
-        attributedHint.draw(
-            at: CGPoint(
-                x: badgeRect.minX + padding.width,
-                y: badgeRect.minY + padding.height
-            )
-        )
     }
 
     private func drawHandles(for rect: CGRect) {
         for handle in Handle.allCases {
             let center = handlePoint(handle, in: rect)
-            let square = CGRect(
+            let sq = CGRect(
                 x: center.x - handleLength / 2,
                 y: center.y - handleLength / 2,
-                width: handleLength,
+                width:  handleLength,
                 height: handleLength
             )
-            let path = NSBezierPath(roundedRect: square, xRadius: 2, yRadius: 2)
+            let path = NSBezierPath(roundedRect: sq, xRadius: 2, yRadius: 2)
             NSColor.white.setFill()
             path.fill()
             NSColor.black.withAlphaComponent(0.55).setStroke()
@@ -253,78 +355,108 @@ private final class RecordingAreaSelectionView: NSView {
         }
     }
 
-    // MARK: - Mouse
-
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        true
+    private func drawHint(_ text: String) {
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font:            NSFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: NSColor.white
+        ]
+        let str      = NSAttributedString(string: text, attributes: attrs)
+        let textSize = str.size()
+        let pad      = CGSize(width: 14, height: 9)
+        let badgeSize = CGSize(
+            width:  textSize.width  + pad.width  * 2,
+            height: textSize.height + pad.height * 2
+        )
+        let badgeRect = CGRect(
+            x: bounds.midX - badgeSize.width / 2,
+            y: bounds.maxY - badgeSize.height - 28,
+            width:  badgeSize.width,
+            height: badgeSize.height
+        )
+        NSColor.black.withAlphaComponent(0.62).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 9, yRadius: 9).fill()
+        str.draw(at: CGPoint(
+            x: badgeRect.minX + pad.width,
+            y: badgeRect.minY + pad.height
+        ))
     }
+
+    // MARK: - Mouse events
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
 
-        if let selection {
-            if event.clickCount >= 2, selection.contains(point) {
-                commitSelection()
+        if let sel = selection {
+            // Double-click inside → commit
+            if event.clickCount >= 2, sel.contains(point) {
+                commitSelection(); return
+            }
+            // Hit-test a resize handle
+            if let handle = handle(at: point, in: sel) {
+                dragMode     = .resizing(handle)
+                resizeAnchor = sel
                 return
             }
-            if let handle = handle(at: point, in: selection) {
-                dragMode = .resizing(handle)
-                resizeAnchor = selection
-                return
-            }
-            if selection.contains(point) {
-                dragMode = .moving
-                moveOffset = CGSize(width: point.x - selection.minX, height: point.y - selection.minY)
+            // Inside body → move
+            if sel.contains(point) {
+                dragMode   = .moving
+                moveOffset = CGSize(
+                    width:  point.x - sel.minX,
+                    height: point.y - sel.minY
+                )
                 NSCursor.closedHand.set()
                 return
             }
         }
 
-        dragMode = .drawing
+        // Outside (or no selection) → start a new draw
+        dragMode  = .drawing
         selection = nil
-        drawStart = point
+        onSelectionChanged?(nil)
+        drawStart   = point
         drawCurrent = point
         needsDisplay = true
     }
 
     override func mouseDragged(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-
         switch dragMode {
         case .drawing:
             drawCurrent = point
         case .moving:
-            if let current = selection {
-                var moved = current
-                moved.origin = CGPoint(
-                    x: point.x - moveOffset.width,
-                    y: point.y - moveOffset.height
-                )
-                selection = clampToBounds(moved)
-            }
+            guard let cur = selection else { break }
+            var moved = cur
+            moved.origin = CGPoint(
+                x: point.x - moveOffset.width,
+                y: point.y - moveOffset.height
+            )
+            selection = clampToBounds(moved)
+            onSelectionChanged?(selection)
         case .resizing(let handle):
             selection = resizedRect(anchor: resizeAnchor, handle: handle, to: point)
+            onSelectionChanged?(selection)
         case .none:
             break
         }
-
         needsDisplay = true
     }
 
     override func mouseUp(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-
         if case .drawing = dragMode {
             drawCurrent = point
-            if let rect = draftRect, rect.width >= minimumSize, rect.height >= minimumSize {
+            if let rect = draftRect,
+               rect.width >= minimumSize, rect.height >= minimumSize {
                 selection = clampToBounds(rect)
             } else {
                 selection = nil
             }
-            drawStart = nil
+            drawStart   = nil
             drawCurrent = nil
+            onSelectionChanged?(selection)
         }
-
         dragMode = .none
         needsDisplay = true
         window?.invalidateCursorRects(for: self)
@@ -332,12 +464,9 @@ private final class RecordingAreaSelectionView: NSView {
 
     override func keyDown(with event: NSEvent) {
         switch event.keyCode {
-        case 53:            // Escape
-            onCancel?()
-        case 36, 76:        // Return / keypad Enter
-            commitSelection()
-        default:
-            super.keyDown(with: event)
+        case 53:       onCancel?()        // Esc
+        case 36, 76:   commitSelection()  // Return / keypad Enter
+        default:       super.keyDown(with: event)
         }
     }
 
@@ -346,7 +475,7 @@ private final class RecordingAreaSelectionView: NSView {
         onSelect?(selection)
     }
 
-    // MARK: - Geometry
+    // MARK: - Geometry helpers
 
     private func handlePoint(_ handle: Handle, in rect: CGRect) -> CGPoint {
         switch handle {
@@ -362,57 +491,112 @@ private final class RecordingAreaSelectionView: NSView {
     }
 
     private func handleHitRect(_ handle: Handle, in rect: CGRect) -> CGRect {
-        let center = handlePoint(handle, in: rect)
-        let reach = handleLength / 2 + handleHitPadding
-        return CGRect(
-            x: center.x - reach,
-            y: center.y - reach,
-            width: reach * 2,
-            height: reach * 2
-        )
+        let c     = handlePoint(handle, in: rect)
+        let reach = handleLength / 2 + handleHitPad
+        return CGRect(x: c.x - reach, y: c.y - reach, width: reach * 2, height: reach * 2)
     }
 
     private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
         Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
     }
 
-    private func resizedRect(anchor: CGRect, handle: Handle, to rawPoint: CGPoint) -> CGRect {
-        var minX = anchor.minX
-        var maxX = anchor.maxX
-        var minY = anchor.minY
-        var maxY = anchor.maxY
+    private func resizedRect(anchor: CGRect, handle: Handle, to raw: CGPoint) -> CGRect {
+        let ratio = aspect.pixelRatio(imageSize: .zero)
+        let px = max(bounds.minX, min(raw.x, bounds.maxX))
+        let py = max(bounds.minY, min(raw.y, bounds.maxY))
+        let p  = CGPoint(x: px, y: py)
 
-        let px = max(bounds.minX, min(rawPoint.x, bounds.maxX))
-        let py = max(bounds.minY, min(rawPoint.y, bounds.maxY))
-
+        // Corner handles: aspect-locked when a preset is active.
         switch handle {
-        case .left, .topLeft, .bottomLeft:
-            minX = min(px, anchor.maxX - minimumSize)
-        case .right, .topRight, .bottomRight:
-            maxX = max(px, anchor.minX + minimumSize)
+        case .topLeft:
+            if let r = ratio {
+                return aspectLockedCorner(
+                    anchorX: anchor.maxX, anchorY: anchor.minY,
+                    signX: -1, signY: +1, to: p, ratio: r)
+            }
+        case .topRight:
+            if let r = ratio {
+                return aspectLockedCorner(
+                    anchorX: anchor.minX, anchorY: anchor.minY,
+                    signX: +1, signY: +1, to: p, ratio: r)
+            }
+        case .bottomLeft:
+            if let r = ratio {
+                return aspectLockedCorner(
+                    anchorX: anchor.maxX, anchorY: anchor.maxY,
+                    signX: -1, signY: -1, to: p, ratio: r)
+            }
+        case .bottomRight:
+            if let r = ratio {
+                return aspectLockedCorner(
+                    anchorX: anchor.minX, anchorY: anchor.maxY,
+                    signX: +1, signY: -1, to: p, ratio: r)
+            }
         default:
             break
         }
 
+        // Edge handles (or freeform corners): unconstrained.
+        var minX = anchor.minX, maxX = anchor.maxX
+        var minY = anchor.minY, maxY = anchor.maxY
+
         switch handle {
-        case .bottom, .bottomLeft, .bottomRight:
-            minY = min(py, anchor.maxY - minimumSize)
-        case .top, .topLeft, .topRight:
-            maxY = max(py, anchor.minY + minimumSize)
-        default:
-            break
+        case .left,        .topLeft,     .bottomLeft:  minX = min(px, anchor.maxX - minimumSize)
+        case .right,       .topRight,    .bottomRight: maxX = max(px, anchor.minX + minimumSize)
+        default: break
+        }
+        switch handle {
+        case .bottom,      .bottomLeft,  .bottomRight: minY = min(py, anchor.maxY - minimumSize)
+        case .top,         .topLeft,     .topRight:    maxY = max(py, anchor.minY + minimumSize)
+        default: break
         }
 
         return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
     }
 
+    /// Resize a corner handle while locking to `ratio` (width ÷ height).
+    ///
+    /// - Parameters:
+    ///   - anchorX/Y: The fixed opposite corner (NSView y-up coordinates).
+    ///   - signX:     +1 = drag grows rightward, −1 = leftward.
+    ///   - signY:     +1 = drag grows upward,    −1 = downward.
+    private func aspectLockedCorner(
+        anchorX: CGFloat, anchorY: CGFloat,
+        signX: CGFloat,   signY: CGFloat,
+        to point: CGPoint,
+        ratio: CGFloat
+    ) -> CGRect {
+        let cw = max((point.x - anchorX) * signX, minimumSize)
+        let ch = max((point.y - anchorY) * signY, minimumSize)
+
+        var w: CGFloat
+        var h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+
+        // Clamp to screen bounds while preserving ratio
+        let maxW = signX > 0 ? bounds.maxX - anchorX : anchorX - bounds.minX
+        let maxH = signY > 0 ? bounds.maxY - anchorY : anchorY - bounds.minY
+        if w > maxW { w = maxW; h = w / ratio }
+        if h > maxH { h = maxH; w = h * ratio }
+        w = max(w, minimumSize)
+        h = max(h, minimumSize)
+
+        return CGRect(
+            x:      signX > 0 ? anchorX      : anchorX - w,
+            y:      signY > 0 ? anchorY      : anchorY - h,
+            width:  w,
+            height: h
+        )
+    }
+
     private func clampToBounds(_ rect: CGRect) -> CGRect {
-        var result = rect
-        result.size.width = min(result.size.width, bounds.width)
-        result.size.height = min(result.size.height, bounds.height)
-        result.origin.x = max(bounds.minX, min(result.origin.x, bounds.maxX - result.width))
-        result.origin.y = max(bounds.minY, min(result.origin.y, bounds.maxY - result.height))
-        return result
+        var r = rect
+        r.size.width  = min(r.size.width,  bounds.width)
+        r.size.height = min(r.size.height, bounds.height)
+        r.origin.x    = max(bounds.minX, min(r.origin.x, bounds.maxX - r.width))
+        r.origin.y    = max(bounds.minY, min(r.origin.y, bounds.maxY - r.height))
+        return r
     }
 
     // MARK: - Cursor
@@ -420,67 +604,54 @@ private final class RecordingAreaSelectionView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.invalidateCursorRects(for: self)
-        if window != nil {
-            NSCursor.annotationPlus.set()
-        }
+        if window != nil { NSCursor.annotationPlus.set() }
     }
 
     override func resetCursorRects() {
         addCursorRect(bounds, cursor: .annotationPlus)
-
         guard let selection, !isDrawing else { return }
-
         addCursorRect(selection, cursor: .openHand)
         for handle in Handle.allCases {
-            addCursorRect(handleHitRect(handle, in: selection), cursor: cursor(for: handle))
+            addCursorRect(handleHitRect(handle, in: selection), cursor: cursorFor(handle))
         }
     }
 
-    private func cursor(for handle: Handle) -> NSCursor {
+    private func cursorFor(_ handle: Handle) -> NSCursor {
         switch handle {
-        case .left, .right:
-            return .resizeLeftRight
-        case .top, .bottom:
-            return .resizeUpDown
-        case .topLeft, .topRight, .bottomLeft, .bottomRight:
-            return .crosshair
+        case .left, .right:  return .resizeLeftRight
+        case .top, .bottom:  return .resizeUpDown
+        default:             return .crosshair
         }
     }
 
     // MARK: - Size badge
 
     private func drawSelectionSize(for rect: CGRect) {
-        let pixelWidth = Int((rect.width * pixelScale.width).rounded())
-        let pixelHeight = Int((rect.height * pixelScale.height).rounded())
-        let label = "\(pixelWidth) x \(pixelHeight)"
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold),
+        let pw = Int((rect.width  * pixelScale.width).rounded())
+        let ph = Int((rect.height * pixelScale.height).rounded())
+        let label = "\(pw) x \(ph)"
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font:            NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold),
             .foregroundColor: NSColor.white
         ]
-        let attributedLabel = NSAttributedString(string: label, attributes: attributes)
-        let textSize = attributedLabel.size()
-        let padding = CGSize(width: 10, height: 6)
-        let badgeSize = CGSize(width: textSize.width + padding.width * 2, height: textSize.height + padding.height * 2)
-        let badgeOrigin = badgeOrigin(for: rect, size: badgeSize)
-        let badgeRect = CGRect(origin: badgeOrigin, size: badgeSize)
+        let str      = NSAttributedString(string: label, attributes: attrs)
+        let textSize = str.size()
+        let pad      = CGSize(width: 10, height: 6)
+        let badgeSize = CGSize(
+            width:  textSize.width  + pad.width  * 2,
+            height: textSize.height + pad.height * 2
+        )
+        let origin    = badgeOrigin(for: rect, size: badgeSize)
+        let badgeRect = CGRect(origin: origin, size: badgeSize)
 
         NSColor.black.withAlphaComponent(0.72).setFill()
         NSBezierPath(roundedRect: badgeRect, xRadius: 7, yRadius: 7).fill()
-
-        attributedLabel.draw(
-            at: CGPoint(
-                x: badgeRect.minX + padding.width,
-                y: badgeRect.minY + padding.height
-            )
-        )
+        str.draw(at: CGPoint(x: badgeRect.minX + pad.width, y: badgeRect.minY + pad.height))
     }
 
     private func badgeOrigin(for rect: CGRect, size: CGSize) -> CGPoint {
         let preferred = CGPoint(x: rect.minX, y: rect.minY - size.height - 8)
-        if bounds.contains(CGRect(origin: preferred, size: size)) {
-            return preferred
-        }
-
+        if bounds.contains(CGRect(origin: preferred, size: size)) { return preferred }
         let fallbackY = min(rect.maxY + 8, bounds.maxY - size.height - 8)
         return CGPoint(
             x: min(max(rect.minX, bounds.minX + 8), bounds.maxX - size.width - 8),

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -92,7 +92,11 @@ final class RecordingAreaSelectionPresenter {
         installKeyMonitor()
         overlayPanel.makeKeyAndOrderFront(nil)
         overlayPanel.orderFrontRegardless()
-        toolbarPanel?.orderFrontRegardless()
+        // Attach toolbar as a child window so the window server keeps it above
+        // the overlay regardless of subsequent mouse interactions on the overlay.
+        if let tp = toolbarPanel {
+            overlayPanel.addChildWindow(tp, ordered: .above)
+        }
     }
 
     func cancel() {
@@ -108,7 +112,10 @@ final class RecordingAreaSelectionPresenter {
         model            = nil
         selectionView    = nil
         removeKeyMonitor()
-        toolbarPanel?.orderOut(nil)
+        if let tp = toolbarPanel {
+            panel?.removeChildWindow(tp)
+            tp.orderOut(nil)
+        }
         toolbarPanel = nil
         panel?.orderOut(nil)
         panel = nil

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -75,7 +75,6 @@ final class RecordingAreaSelectionPresenter {
         installKeyMonitor()
         panel.makeKeyAndOrderFront(nil)
         panel.orderFrontRegardless()
-        selectionView.beginSelectionCursorSession()
     }
 
     func cancel() {
@@ -87,7 +86,6 @@ final class RecordingAreaSelectionPresenter {
         self.completion = nil
         display = nil
         removeKeyMonitor()
-        (panel?.contentView as? RecordingAreaSelectionView)?.endSelectionCursorSession()
         panel?.orderOut(nil)
         panel = nil
         completion?(rect)
@@ -121,10 +119,28 @@ private final class RecordingAreaSelectionView: NSView {
     var onSelect: ((CGRect) -> Void)?
     var onCancel: (() -> Void)?
 
-    private var startPoint: CGPoint?
-    private var currentPoint: CGPoint?
+    private enum DragMode {
+        case none
+        case drawing
+        case moving
+        case resizing(Handle)
+    }
+
+    private enum Handle: CaseIterable {
+        case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
+    }
+
     private let pixelScale: CGSize
-    private var didPushSelectionCursor = false
+    private let minimumSize: CGFloat = 16
+    private let handleLength: CGFloat = 10
+    private let handleHitPadding: CGFloat = 6
+
+    private var selection: CGRect?
+    private var drawStart: CGPoint?
+    private var drawCurrent: CGPoint?
+    private var dragMode: DragMode = .none
+    private var moveOffset: CGSize = .zero
+    private var resizeAnchor: CGRect = .zero
 
     override var acceptsFirstResponder: Bool {
         true
@@ -140,95 +156,298 @@ private final class RecordingAreaSelectionView: NSView {
         nil
     }
 
-    deinit {
-        endSelectionCursorSession()
+    // MARK: - Active rect
+
+    private var draftRect: CGRect? {
+        guard let drawStart, let drawCurrent else { return nil }
+
+        return CGRect(
+            x: min(drawStart.x, drawCurrent.x),
+            y: min(drawStart.y, drawCurrent.y),
+            width: abs(drawStart.x - drawCurrent.x),
+            height: abs(drawStart.y - drawCurrent.y)
+        )
     }
+
+    private var isDrawing: Bool {
+        if case .drawing = dragMode { return true }
+        return false
+    }
+
+    private var activeRect: CGRect? {
+        isDrawing ? draftRect : selection
+    }
+
+    // MARK: - Drawing
 
     override func draw(_ dirtyRect: NSRect) {
         NSColor.black.withAlphaComponent(0.28).setFill()
         bounds.fill()
 
-        guard let selectionRect else { return }
+        if let rect = activeRect {
+            NSColor.clear.setFill()
+            rect.fill(using: .clear)
 
-        NSColor.clear.setFill()
-        selectionRect.fill(using: .clear)
+            NSColor.white.withAlphaComponent(0.96).setStroke()
+            let border = NSBezierPath(roundedRect: rect, xRadius: 4, yRadius: 4)
+            border.lineWidth = 2
+            border.stroke()
 
-        NSColor.white.withAlphaComponent(0.96).setStroke()
-        let border = NSBezierPath(roundedRect: selectionRect, xRadius: 4, yRadius: 4)
-        border.lineWidth = 2
-        border.stroke()
+            drawSelectionSize(for: rect)
 
-        drawSelectionSize(for: selectionRect)
+            if !isDrawing, selection != nil {
+                drawHandles(for: rect)
+            }
+        }
+
+        if !isDrawing {
+            drawHint()
+        }
     }
 
-    override func resetCursorRects() {
-        addCursorRect(bounds, cursor: .annotationPlus)
+    private func drawHint() {
+        let text = selection == nil
+            ? "Drag to select an area    Esc to cancel"
+            : "Return to record    Drag to adjust    Esc to cancel"
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: NSColor.white
+        ]
+        let attributedHint = NSAttributedString(string: text, attributes: attributes)
+        let textSize = attributedHint.size()
+        let padding = CGSize(width: 14, height: 9)
+        let badgeSize = CGSize(width: textSize.width + padding.width * 2, height: textSize.height + padding.height * 2)
+        let badgeRect = CGRect(
+            x: bounds.midX - badgeSize.width / 2,
+            y: bounds.maxY - badgeSize.height - 28,
+            width: badgeSize.width,
+            height: badgeSize.height
+        )
+
+        NSColor.black.withAlphaComponent(0.62).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 9, yRadius: 9).fill()
+
+        attributedHint.draw(
+            at: CGPoint(
+                x: badgeRect.minX + padding.width,
+                y: badgeRect.minY + padding.height
+            )
+        )
     }
+
+    private func drawHandles(for rect: CGRect) {
+        for handle in Handle.allCases {
+            let center = handlePoint(handle, in: rect)
+            let square = CGRect(
+                x: center.x - handleLength / 2,
+                y: center.y - handleLength / 2,
+                width: handleLength,
+                height: handleLength
+            )
+            let path = NSBezierPath(roundedRect: square, xRadius: 2, yRadius: 2)
+            NSColor.white.setFill()
+            path.fill()
+            NSColor.black.withAlphaComponent(0.55).setStroke()
+            path.lineWidth = 1
+            path.stroke()
+        }
+    }
+
+    // MARK: - Mouse
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if let selection {
+            if event.clickCount >= 2, selection.contains(point) {
+                commitSelection()
+                return
+            }
+            if let handle = handle(at: point, in: selection) {
+                dragMode = .resizing(handle)
+                resizeAnchor = selection
+                return
+            }
+            if selection.contains(point) {
+                dragMode = .moving
+                moveOffset = CGSize(width: point.x - selection.minX, height: point.y - selection.minY)
+                NSCursor.closedHand.set()
+                return
+            }
+        }
+
+        dragMode = .drawing
+        selection = nil
+        drawStart = point
+        drawCurrent = point
+        needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        switch dragMode {
+        case .drawing:
+            drawCurrent = point
+        case .moving:
+            if let current = selection {
+                var moved = current
+                moved.origin = CGPoint(
+                    x: point.x - moveOffset.width,
+                    y: point.y - moveOffset.height
+                )
+                selection = clampToBounds(moved)
+            }
+        case .resizing(let handle):
+            selection = resizedRect(anchor: resizeAnchor, handle: handle, to: point)
+        case .none:
+            break
+        }
+
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if case .drawing = dragMode {
+            drawCurrent = point
+            if let rect = draftRect, rect.width >= minimumSize, rect.height >= minimumSize {
+                selection = clampToBounds(rect)
+            } else {
+                selection = nil
+            }
+            drawStart = nil
+            drawCurrent = nil
+        }
+
+        dragMode = .none
+        needsDisplay = true
+        window?.invalidateCursorRects(for: self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 53:            // Escape
+            onCancel?()
+        case 36, 76:        // Return / keypad Enter
+            commitSelection()
+        default:
+            super.keyDown(with: event)
+        }
+    }
+
+    private func commitSelection() {
+        guard let selection else { return }
+        onSelect?(selection)
+    }
+
+    // MARK: - Geometry
+
+    private func handlePoint(_ handle: Handle, in rect: CGRect) -> CGPoint {
+        switch handle {
+        case .topLeft:     return CGPoint(x: rect.minX, y: rect.maxY)
+        case .top:         return CGPoint(x: rect.midX, y: rect.maxY)
+        case .topRight:    return CGPoint(x: rect.maxX, y: rect.maxY)
+        case .right:       return CGPoint(x: rect.maxX, y: rect.midY)
+        case .bottomRight: return CGPoint(x: rect.maxX, y: rect.minY)
+        case .bottom:      return CGPoint(x: rect.midX, y: rect.minY)
+        case .bottomLeft:  return CGPoint(x: rect.minX, y: rect.minY)
+        case .left:        return CGPoint(x: rect.minX, y: rect.midY)
+        }
+    }
+
+    private func handleHitRect(_ handle: Handle, in rect: CGRect) -> CGRect {
+        let center = handlePoint(handle, in: rect)
+        let reach = handleLength / 2 + handleHitPadding
+        return CGRect(
+            x: center.x - reach,
+            y: center.y - reach,
+            width: reach * 2,
+            height: reach * 2
+        )
+    }
+
+    private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
+        Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
+    }
+
+    private func resizedRect(anchor: CGRect, handle: Handle, to rawPoint: CGPoint) -> CGRect {
+        var minX = anchor.minX
+        var maxX = anchor.maxX
+        var minY = anchor.minY
+        var maxY = anchor.maxY
+
+        let px = max(bounds.minX, min(rawPoint.x, bounds.maxX))
+        let py = max(bounds.minY, min(rawPoint.y, bounds.maxY))
+
+        switch handle {
+        case .left, .topLeft, .bottomLeft:
+            minX = min(px, anchor.maxX - minimumSize)
+        case .right, .topRight, .bottomRight:
+            maxX = max(px, anchor.minX + minimumSize)
+        default:
+            break
+        }
+
+        switch handle {
+        case .bottom, .bottomLeft, .bottomRight:
+            minY = min(py, anchor.maxY - minimumSize)
+        case .top, .topLeft, .topRight:
+            maxY = max(py, anchor.minY + minimumSize)
+        default:
+            break
+        }
+
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    private func clampToBounds(_ rect: CGRect) -> CGRect {
+        var result = rect
+        result.size.width = min(result.size.width, bounds.width)
+        result.size.height = min(result.size.height, bounds.height)
+        result.origin.x = max(bounds.minX, min(result.origin.x, bounds.maxX - result.width))
+        result.origin.y = max(bounds.minY, min(result.origin.y, bounds.maxY - result.height))
+        return result
+    }
+
+    // MARK: - Cursor
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.invalidateCursorRects(for: self)
         if window != nil {
-            beginSelectionCursorSession()
-        } else {
-            endSelectionCursorSession()
-        }
-    }
-
-    override func cursorUpdate(with event: NSEvent) {
-        beginSelectionCursorSession()
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        startPoint = point
-        currentPoint = point
-        needsDisplay = true
-    }
-
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        beginSelectionCursorSession()
-        return true
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-        currentPoint = convert(event.locationInWindow, from: nil)
-        needsDisplay = true
-    }
-
-    override func mouseUp(with event: NSEvent) {
-        currentPoint = convert(event.locationInWindow, from: nil)
-        guard let rect = selectionRect, rect.width >= 16, rect.height >= 16 else {
-            onCancel?()
-            return
-        }
-
-        onSelect?(rect)
-    }
-
-    override func keyDown(with event: NSEvent) {
-        if event.keyCode == 53 {
-            onCancel?()
-        } else {
-            super.keyDown(with: event)
-        }
-    }
-
-    func beginSelectionCursorSession() {
-        if didPushSelectionCursor {
             NSCursor.annotationPlus.set()
-        } else {
-            NSCursor.annotationPlus.push()
-            didPushSelectionCursor = true
         }
     }
 
-    func endSelectionCursorSession() {
-        guard didPushSelectionCursor else { return }
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .annotationPlus)
 
-        NSCursor.pop()
-        didPushSelectionCursor = false
+        guard let selection, !isDrawing else { return }
+
+        addCursorRect(selection, cursor: .openHand)
+        for handle in Handle.allCases {
+            addCursorRect(handleHitRect(handle, in: selection), cursor: cursor(for: handle))
+        }
     }
+
+    private func cursor(for handle: Handle) -> NSCursor {
+        switch handle {
+        case .left, .right:
+            return .resizeLeftRight
+        case .top, .bottom:
+            return .resizeUpDown
+        case .topLeft, .topRight, .bottomLeft, .bottomRight:
+            return .crosshair
+        }
+    }
+
+    // MARK: - Size badge
 
     private func drawSelectionSize(for rect: CGRect) {
         let pixelWidth = Int((rect.width * pixelScale.width).rounded())
@@ -266,17 +485,6 @@ private final class RecordingAreaSelectionView: NSView {
         return CGPoint(
             x: min(max(rect.minX, bounds.minX + 8), bounds.maxX - size.width - 8),
             y: max(fallbackY, bounds.minY + 8)
-        )
-    }
-
-    private var selectionRect: CGRect? {
-        guard let startPoint, let currentPoint else { return nil }
-
-        return CGRect(
-            x: min(startPoint.x, currentPoint.x),
-            y: min(startPoint.y, currentPoint.y),
-            width: abs(startPoint.x - currentPoint.x),
-            height: abs(startPoint.y - currentPoint.y)
         )
     }
 }

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -145,9 +145,8 @@ final class RecordingAreaSelectionPresenter {
             model:          model,
             onStart:        { [weak self] in self?.finishWithModelSelection() },
             onCancel:       { [weak self] in self?.cancel() },
-            onAspectChange: { [weak self] aspect in
-                self?.selectionView?.applyAspect(aspect)
-            }
+            onAspectChange: { [weak self] aspect in self?.selectionView?.applyAspect(aspect) },
+            onModeChange:   { _ in }   // mode switching handled by RecordingSetupPresenter (PR 3)
         )
 
         let hosting     = NSHostingView(rootView: toolbarView)

--- a/Screendrop/RecordingSetupModel.swift
+++ b/Screendrop/RecordingSetupModel.swift
@@ -1,0 +1,40 @@
+//
+//  RecordingSetupModel.swift
+//  Screendrop
+//
+//  Shared state between the area-selection overlay and the recording setup
+//  toolbar. Both surfaces read and write through this model; the presenter
+//  is the single owner that keeps them in sync.
+//
+
+import CoreGraphics
+import Observation
+
+@MainActor
+@Observable
+final class RecordingSetupModel {
+
+    /// The active aspect-ratio constraint.  `.freeform` means unconstrained.
+    var aspect: CropAspectRatio = .freeform
+
+    /// The committed selection rectangle in overlay-panel-local coordinates.
+    /// `nil` until the user draws a region; the Start button stays disabled
+    /// until this is set.
+    var selection: CGRect?
+
+    /// Point-to-pixel scale for the target display (used to show pixel dimensions).
+    let pixelScale: CGSize
+
+    /// Live pixel dimensions of the current selection, or `nil` when none.
+    var pixelSize: CGSize? {
+        guard let rect = selection else { return nil }
+        return CGSize(
+            width:  (rect.width  * pixelScale.width).rounded(),
+            height: (rect.height * pixelScale.height).rounded()
+        )
+    }
+
+    init(pixelScale: CGSize) {
+        self.pixelScale = pixelScale
+    }
+}

--- a/Screendrop/RecordingSetupToolbarView.swift
+++ b/Screendrop/RecordingSetupToolbarView.swift
@@ -1,0 +1,112 @@
+//
+//  RecordingSetupToolbarView.swift
+//  Screendrop
+//
+//  Floating toolbar shown during area-recording setup. Displays aspect-ratio
+//  preset chips, a live pixel-size readout, and Start / Cancel actions.
+//  Hosted in a borderless NSPanel by RecordingAreaSelectionPresenter.
+//
+
+import SwiftUI
+
+struct RecordingSetupToolbarView: View {
+
+    @Bindable var model: RecordingSetupModel
+
+    var onStart: () -> Void
+    var onCancel: () -> Void
+    /// Called when the user picks an aspect chip so the AppKit overlay can
+    /// apply the constraint to the current selection synchronously.
+    var onAspectChange: (CropAspectRatio) -> Void
+
+    private let presets: [(aspect: CropAspectRatio, label: String)] = [
+        (.freeform,    "Freeform"),
+        (.sixteenNine, "16:9"),
+        (.nineSixteen, "9:16"),
+        (.square,      "1:1"),
+        (.fourThree,   "4:3"),
+    ]
+
+    var body: some View {
+        HStack(spacing: 10) {
+
+            // Aspect-ratio chips
+            HStack(spacing: 4) {
+                ForEach(presets, id: \.aspect.id) { item in
+                    Button(item.label) {
+                        model.aspect = item.aspect
+                        onAspectChange(item.aspect)
+                    }
+                    .buttonStyle(AspectChipStyle(isActive: model.aspect == item.aspect))
+                }
+            }
+
+            toolbarDivider
+
+            // Live pixel size
+            Group {
+                if let size = model.pixelSize {
+                    Text("\(Int(size.width)) × \(Int(size.height))")
+                } else {
+                    Text("W × H")
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .font(.system(size: 12, weight: .semibold).monospacedDigit())
+            .frame(minWidth: 76, alignment: .leading)
+
+            toolbarDivider
+
+            // Cancel / Start
+            Button("Cancel", action: onCancel)
+                .foregroundStyle(.secondary)
+
+            Button(action: onStart) {
+                Label("Start", systemImage: "record.circle.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+            .disabled(model.selection == nil)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .fixedSize()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.regularMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.22), radius: 10, y: 4)
+        .padding(10)   // give the shadow room to breathe
+    }
+
+    private var toolbarDivider: some View {
+        Rectangle()
+            .fill(Color(nsColor: .separatorColor))
+            .frame(width: 1, height: 20)
+    }
+}
+
+// MARK: - Chip button style
+
+private struct AspectChipStyle: ButtonStyle {
+    let isActive: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 12, weight: .medium))
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(
+                isActive
+                    ? Color.accentColor
+                    : Color(nsColor: .controlColor).opacity(0.7)
+            )
+            .foregroundStyle(isActive ? Color.white : Color.primary)
+            .clipShape(Capsule())
+            .opacity(configuration.isPressed ? 0.75 : 1)
+    }
+}

--- a/Screendrop/RecordingSetupToolbarView.swift
+++ b/Screendrop/RecordingSetupToolbarView.swift
@@ -2,9 +2,11 @@
 //  RecordingSetupToolbarView.swift
 //  Screendrop
 //
-//  Floating toolbar shown during area-recording setup. Displays aspect-ratio
-//  preset chips, a live pixel-size readout, and Start / Cancel actions.
-//  Hosted in a borderless NSPanel by RecordingAreaSelectionPresenter.
+//  Floating toolbar shown during area-recording setup.  Uses a dark HUD
+//  appearance so it reads clearly against the dimmed screen overlay, avoiding
+//  the flat rendering that .regularMaterial produces in non-activating panels.
+//  Start is a vivid red pill (obvious primary action); Cancel is a muted text
+//  label that stays accessible without competing with Start.
 //
 
 import SwiftUI
@@ -13,13 +15,13 @@ struct RecordingSetupToolbarView: View {
 
     @Bindable var model: RecordingSetupModel
 
-    var onStart: () -> Void
-    var onCancel: () -> Void
-    /// Called when the user picks an aspect chip so the AppKit overlay can
-    /// apply the constraint to the current selection synchronously.
+    var onStart:        () -> Void
+    var onCancel:       () -> Void
     var onAspectChange: (CropAspectRatio) -> Void
+    /// Called when a future mode control changes mode (wired in PR 3).
+    var onModeChange:   (Any) -> Void
 
-    private let presets: [(aspect: CropAspectRatio, label: String)] = [
+    private let aspects: [(aspect: CropAspectRatio, label: String)] = [
         (.freeform,    "Freeform"),
         (.sixteenNine, "16:9"),
         (.nineSixteen, "9:16"),
@@ -30,83 +32,107 @@ struct RecordingSetupToolbarView: View {
     var body: some View {
         HStack(spacing: 10) {
 
-            // Aspect-ratio chips
+            // ── Aspect-ratio chips ─────────────────────────────────────────
             HStack(spacing: 4) {
-                ForEach(presets, id: \.aspect.id) { item in
+                ForEach(aspects, id: \.aspect.id) { item in
                     Button(item.label) {
                         model.aspect = item.aspect
                         onAspectChange(item.aspect)
                     }
-                    .buttonStyle(AspectChipStyle(isActive: model.aspect == item.aspect))
+                    .buttonStyle(HUDAspectChipStyle(isActive: model.aspect == item.aspect))
                 }
             }
 
-            toolbarDivider
+            separator
 
-            // Live pixel size
+            // ── Live pixel size ────────────────────────────────────────────
             Group {
                 if let size = model.pixelSize {
                     Text("\(Int(size.width)) × \(Int(size.height))")
+                        .foregroundStyle(.white)
                 } else {
                     Text("W × H")
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.white.opacity(0.4))
                 }
             }
             .font(.system(size: 12, weight: .semibold).monospacedDigit())
             .frame(minWidth: 76, alignment: .leading)
 
-            toolbarDivider
+            separator
 
-            // Cancel / Start
+            // ── Cancel ─────────────────────────────────────────────────────
             Button("Cancel", action: onCancel)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.white.opacity(0.7))
 
+            // ── Start ──────────────────────────────────────────────────────
             Button(action: onStart) {
                 Label("Start", systemImage: "record.circle.fill")
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.red)
+            .buttonStyle(HUDStartButtonStyle())
             .disabled(model.selection == nil)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .fixedSize()
+        // Dark HUD: clear and readable on any dimmed overlay; avoids the
+        // flat appearance of .regularMaterial in non-activating panels.
         .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(.regularMaterial)
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color.black.opacity(0.78))
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.22), radius: 10, y: 4)
-        .padding(10)   // give the shadow room to breathe
+        .shadow(color: .black.opacity(0.5), radius: 16, y: 5)
+        .padding(10)
+        // Force dark scheme so the system controls inside render correctly
+        // on the dark background.
+        .environment(\.colorScheme, .dark)
     }
 
-    private var toolbarDivider: some View {
+    private var separator: some View {
         Rectangle()
-            .fill(Color(nsColor: .separatorColor))
+            .fill(Color.white.opacity(0.18))
             .frame(width: 1, height: 20)
     }
 }
 
-// MARK: - Chip button style
+// MARK: - Button styles
 
-private struct AspectChipStyle: ButtonStyle {
+/// Aspect-ratio chip on the dark HUD toolbar.
+/// Active state: white fill + black text.  Inactive: subtle ghost pill.
+private struct HUDAspectChipStyle: ButtonStyle {
     let isActive: Bool
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(isActive ? Color.black : Color.white)
             .padding(.horizontal, 9)
             .padding(.vertical, 5)
             .background(
                 isActive
-                    ? Color.accentColor
-                    : Color(nsColor: .controlColor).opacity(0.7)
+                    ? Color.white
+                    : Color.white.opacity(0.12)
             )
-            .foregroundStyle(isActive ? Color.white : Color.primary)
             .clipShape(Capsule())
+            .opacity(configuration.isPressed ? 0.7 : 1)
+    }
+}
+
+/// Primary Start button.  Red when enabled, invisible-ish when disabled;
+/// animates between states so the moment a selection is drawn is felt.
+private struct HUDStartButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .background(
+                Capsule()
+                    .fill(isEnabled ? Color.red : Color.white.opacity(0.15))
+            )
             .opacity(configuration.isPressed ? 0.75 : 1)
+            .animation(.easeInOut(duration: 0.18), value: isEnabled)
     }
 }


### PR DESCRIPTION
## What

Area recording now opens a floating toolbar alongside the selection overlay, offering five aspect-ratio presets.

**Aspect-ratio presets** — Freeform / 16:9 / 9:16 / 1:1 / 4:3:
- Picking a preset locks new drags to that ratio as you draw.
- Corner handles maintain the ratio while resizing.
- Switching presets re-fits the existing selection to the new ratio (centered).
- Edge handles remain freeform in all modes.

**Setup toolbar** — floats at the bottom of the display:
- Aspect-ratio chip row.
- Live W×H pixel readout that updates as you drag or resize.
- **Start** button (disabled until a selection exists) and **Cancel** as alternatives to Return / Esc.

## Part of a series

This builds on PR #6 (adjustable area selection). Together they form the first two steps of a planned recording setup HUD — a fuller proposal with all planned PRs is described in the linked issue/discussion.

## New files

| File | Purpose |
|------|---------|
| `RecordingSetupModel.swift` | `@Observable` state shared between the AppKit overlay and the SwiftUI toolbar |
| `RecordingSetupToolbarView.swift` | SwiftUI toolbar: aspect chips, live size readout, Start / Cancel |

## Scope

- Aspect presets apply to **Area mode only**.
- The toolbar panel uses `sharingType = .none` so it is never captured in the recording output.
- No changes to the recording pipeline (`ScreenRecordingSource`, `ScreenRecordingManager`).

## Testing

- `xcodebuild -scheme Screendrop -configuration Debug -destination 'platform=macOS'` → **BUILD SUCCEEDED**.
- Manual: area recording → pick 16:9 → drag stays ratio-locked → corner handle stays locked → switch to 9:16 re-fits selection → Start records the region.

## Demo

_Screen recording to be added._