### PR TITLE
Unified recording setup HUD (Full Screen / Area)

### DIFF
--- a/Screendrop/CaptureCoordinator.swift
+++ b/Screendrop/CaptureCoordinator.swift
@@ -63,6 +63,12 @@ final class CaptureCoordinator {
     }
 
     func recordScreen() {
+        if ScreendropPreferences.showRecordingSetupHUD {
+            RecordingSetupPresenter.shared.begin()
+            return
+        }
+
+        // "Show options before recording" is off — capture full screen immediately.
         let displayID = ActiveDisplayResolver.activeDisplayID(preferPointer: false)
         Task {
             do {

--- a/Screendrop/MenuBarView.swift
+++ b/Screendrop/MenuBarView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 
 struct MenuBarView: View {
     @ObservedObject private var updaterManager = UpdaterManager.shared
-    @State private var recordingSources = RecordingSourceCatalog.shared
     @State private var historyStore = ScreenshotHistoryStore.shared
     
     var body: some View {
@@ -34,10 +33,10 @@ struct MenuBarView: View {
                 Label("Capture Area", systemImage: "rectangle.dashed")
             }
 
-            Menu {
-                recordingMenuContent
+            Button {
+                CaptureCoordinator.shared.recordScreen()
             } label: {
-                Label("Record Screen", systemImage: "record.circle")
+                Label("Record Screen\u{2026}", systemImage: "record.circle")
             }
 
             Divider()
@@ -76,76 +75,7 @@ struct MenuBarView: View {
             .keyboardShortcut("q")
         }
         .task {
-            await recordingSources.refresh()
             historyStore.reload()
-        }
-    }
-
-    @ViewBuilder
-    private var recordingMenuContent: some View {
-        if recordingSources.isLoading {
-            Label("Loading sources...", systemImage: "hourglass")
-        }
-
-        if let errorMessage = recordingSources.errorMessage {
-            Text("Unable to load sources")
-            Text(errorMessage)
-        }
-
-        Menu("Full Screen") {
-            if recordingSources.displays.isEmpty {
-                Text("No displays found")
-            } else {
-                ForEach(Array(recordingSources.displays.enumerated()), id: \.element.displayID) { index, display in
-                    Button(RecordingSourceCatalog.displayTitle(display, index: index)) {
-                        CaptureCoordinator.shared.recordFullscreen(display)
-                    }
-                }
-            }
-        }
-
-        Menu("Area") {
-            if recordingSources.displays.isEmpty {
-                Text("No displays found")
-            } else {
-                ForEach(Array(recordingSources.displays.enumerated()), id: \.element.displayID) { index, display in
-                    Button(RecordingSourceCatalog.displayTitle(display, index: index)) {
-                        CaptureCoordinator.shared.recordArea(display)
-                    }
-                }
-            }
-        }
-
-        Menu("Window") {
-            if recordingSources.windows.isEmpty {
-                Text("No app windows found")
-            } else {
-                ForEach(recordingSources.windows, id: \.windowID) { window in
-                    Button(RecordingSourceCatalog.windowTitle(window)) {
-                        CaptureCoordinator.shared.recordWindow(window)
-                    }
-                }
-            }
-
-            Divider()
-
-            Button {
-                Task {
-                    await recordingSources.refresh()
-                }
-            } label: {
-                Label("Refresh Windows", systemImage: "arrow.clockwise")
-            }
-        }
-
-        Divider()
-
-        Button {
-            Task {
-                await recordingSources.refresh()
-            }
-        } label: {
-            Label("Refresh Sources", systemImage: "arrow.clockwise")
         }
     }
 

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -343,8 +343,16 @@ private final class RecordingAreaSelectionView: NSView {
         }
     }
 
+    /// When an aspect preset is active only the 4 corner handles are shown;
+    /// edge-only handles (top/bottom/left/right) would break the ratio lock.
+    private var activeHandles: [Handle] {
+        aspect.locksAspect
+            ? [.topLeft, .topRight, .bottomLeft, .bottomRight]
+            : Handle.allCases
+    }
+
     private func drawHandles(for rect: CGRect) {
-        for handle in Handle.allCases {
+        for handle in activeHandles {
             let center = handlePoint(handle, in: rect)
             let sq = CGRect(
                 x: center.x - handleLength / 2,
@@ -503,7 +511,7 @@ private final class RecordingAreaSelectionView: NSView {
     }
 
     private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
-        Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
+        activeHandles.first { handleHitRect($0, in: rect).contains(point) }
     }
 
     private func resizedRect(anchor: CGRect, handle: Handle, to raw: CGPoint) -> CGRect {
@@ -617,7 +625,7 @@ private final class RecordingAreaSelectionView: NSView {
         addCursorRect(bounds, cursor: .annotationPlus)
         guard let selection, !isDrawing else { return }
         addCursorRect(selection, cursor: .openHand)
-        for handle in Handle.allCases {
+        for handle in activeHandles {
             addCursorRect(handleHitRect(handle, in: selection), cursor: cursorFor(handle))
         }
     }

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -138,9 +138,8 @@ final class RecordingAreaSelectionPresenter {
             model:          model,
             onStart:        { [weak self] in self?.finishWithModelSelection() },
             onCancel:       { [weak self] in self?.cancel() },
-            onAspectChange: { [weak self] aspect in
-                self?.selectionView?.applyAspect(aspect)
-            }
+            onAspectChange: { [weak self] aspect in self?.selectionView?.applyAspect(aspect) },
+            onModeChange:   { _ in }   // mode switching is handled by RecordingSetupPresenter
         )
 
         let hosting     = NSHostingView(rootView: toolbarView)

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -7,12 +7,18 @@
 
 import AppKit
 import ScreenCaptureKit
+import SwiftUI
+
+// MARK: - Presenter
 
 @MainActor
 final class RecordingAreaSelectionPresenter {
     static let shared = RecordingAreaSelectionPresenter()
 
     private var panel: NSPanel?
+    private var toolbarPanel: NSPanel?
+    private var selectionView: RecordingAreaSelectionView?
+    private var model: RecordingSetupModel?
     private var completion: ((CGRect?) -> Void)?
     private var display: SCDisplay?
     private var keyMonitor: Any?
@@ -27,75 +33,147 @@ final class RecordingAreaSelectionPresenter {
             return
         }
 
-        self.display = display
+        self.display   = display
         self.completion = completion
 
-        let panel = RecordingAreaSelectionPanel(
-            contentRect: screen.frame,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
+        let pixelScale = CGSize(
+            width:  CGFloat(display.width)  / max(screen.frame.width,  1),
+            height: CGFloat(display.height) / max(screen.frame.height, 1)
         )
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.hasShadow = false
-        panel.level = .screenSaver
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        panel.isReleasedWhenClosed = false
-        panel.acceptsMouseMovedEvents = true
 
-        let selectionView = RecordingAreaSelectionView(
-            frame: CGRect(origin: .zero, size: screen.frame.size),
-            pixelScale: CGSize(
-                width: CGFloat(display.width) / max(screen.frame.width, 1),
-                height: CGFloat(display.height) / max(screen.frame.height, 1)
-            )
+        // Shared observable model
+        let setupModel = RecordingSetupModel(pixelScale: pixelScale)
+        self.model = setupModel
+
+        // ── Overlay panel ──────────────────────────────────────────────────
+        let overlayPanel = RecordingAreaSelectionPanel(
+            contentRect: screen.frame,
+            styleMask:   [.borderless, .nonactivatingPanel],
+            backing:     .buffered,
+            defer:       false
         )
-        selectionView.onCancel = { [weak self] in
+        overlayPanel.backgroundColor          = .clear
+        overlayPanel.isOpaque                 = false
+        overlayPanel.hasShadow                = false
+        overlayPanel.level                    = .screenSaver
+        overlayPanel.collectionBehavior       = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        overlayPanel.isReleasedWhenClosed     = false
+        overlayPanel.acceptsMouseMovedEvents  = true
+
+        let selView = RecordingAreaSelectionView(
+            frame:      CGRect(origin: .zero, size: screen.frame.size),
+            pixelScale: pixelScale
+        )
+
+        // Cancel from overlay
+        selView.onCancel = { [weak self] in
             self?.finish(rect: nil)
         }
-        selectionView.onSelect = { [weak self, weak panel] localRect in
-            guard let self, let panel else {
-                self?.finish(rect: nil)
-                return
-            }
 
-            let globalRect = CGRect(
-                x: panel.frame.minX + localRect.minX,
-                y: panel.frame.minY + localRect.minY,
-                width: localRect.width,
-                height: localRect.height
-            )
-            self.finish(rect: globalRect)
+        // Confirm from Return key or double-click — passes local rect directly
+        selView.onSelect = { [weak self, weak overlayPanel] localRect in
+            guard let self, let overlayPanel else { self?.finish(rect: nil); return }
+            self.finish(rect: self.toGlobal(localRect, panel: overlayPanel))
         }
 
-        panel.contentView = selectionView
-        panel.makeFirstResponder(selectionView)
-        self.panel = panel
+        // Keep model.selection in sync for the toolbar's size readout + Start enable state
+        selView.onSelectionChanged = { [weak setupModel] rect in
+            setupModel?.selection = rect
+        }
+
+        overlayPanel.contentView        = selView
+        overlayPanel.makeFirstResponder(selView)
+        self.panel         = overlayPanel
+        self.selectionView = selView
+
+        // ── Toolbar panel ──────────────────────────────────────────────────
+        toolbarPanel = makeToolbarPanel(screen: screen, model: setupModel)
+
         installKeyMonitor()
-        panel.makeKeyAndOrderFront(nil)
-        panel.orderFrontRegardless()
+        overlayPanel.makeKeyAndOrderFront(nil)
+        overlayPanel.orderFrontRegardless()
+        toolbarPanel?.orderFrontRegardless()
     }
 
     func cancel() {
         finish(rect: nil)
     }
 
+    // MARK: Private
+
     private func finish(rect: CGRect?) {
-        let completion = completion
-        self.completion = nil
-        display = nil
+        let completion  = completion
+        self.completion  = nil
+        display          = nil
+        model            = nil
+        selectionView    = nil
         removeKeyMonitor()
+        toolbarPanel?.orderOut(nil)
+        toolbarPanel = nil
         panel?.orderOut(nil)
         panel = nil
         completion?(rect)
     }
 
+    /// Convert a panel-local rect to global screen coordinates.
+    private func toGlobal(_ localRect: CGRect, panel: NSPanel) -> CGRect {
+        CGRect(
+            x:      panel.frame.minX + localRect.minX,
+            y:      panel.frame.minY + localRect.minY,
+            width:  localRect.width,
+            height: localRect.height
+        )
+    }
+
+    /// Called by the toolbar's Start button — reads the committed selection
+    /// from the model and converts it to global coordinates.
+    private func finishWithModelSelection() {
+        guard let model, let panel else { return }
+        guard let localRect = model.selection   else { return }
+        finish(rect: toGlobal(localRect, panel: panel))
+    }
+
+    private func makeToolbarPanel(screen: NSScreen, model: RecordingSetupModel) -> NSPanel {
+        let toolbarView = RecordingSetupToolbarView(
+            model:          model,
+            onStart:        { [weak self] in self?.finishWithModelSelection() },
+            onCancel:       { [weak self] in self?.cancel() },
+            onAspectChange: { [weak self] aspect in
+                self?.selectionView?.applyAspect(aspect)
+            }
+        )
+
+        let hosting     = NSHostingView(rootView: toolbarView)
+        let idealSize   = hosting.fittingSize
+        let panelWidth  = max(idealSize.width,  480)
+        let panelHeight = idealSize.height > 0 ? idealSize.height : 72
+
+        let panel = NSPanel(
+            contentRect: CGRect(
+                x: screen.frame.midX - panelWidth / 2,
+                y: screen.frame.minY + 32,
+                width:  panelWidth,
+                height: panelHeight
+            ),
+            styleMask:   [.borderless, .nonactivatingPanel],
+            backing:     .buffered,
+            defer:       false
+        )
+        panel.backgroundColor          = .clear
+        panel.isOpaque                 = false
+        panel.hasShadow                = false
+        panel.level                    = .screenSaver
+        panel.collectionBehavior       = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.isReleasedWhenClosed     = false
+        panel.sharingType              = .none   // excluded from recordings
+        panel.contentView              = hosting
+        return panel
+    }
+
     private func installKeyMonitor() {
         removeKeyMonitor()
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.keyCode == 53 else { return event }
-
+            guard event.keyCode == 53 else { return event }   // Esc
             self?.finish(rect: nil)
             return nil
         }
@@ -109,15 +187,26 @@ final class RecordingAreaSelectionPresenter {
     }
 }
 
+// MARK: - Panel subclass
+
 private final class RecordingAreaSelectionPanel: NSPanel {
-    override var canBecomeKey: Bool {
-        true
-    }
+    override var canBecomeKey: Bool { true }
 }
 
+// MARK: - Selection view
+
 private final class RecordingAreaSelectionView: NSView {
-    var onSelect: ((CGRect) -> Void)?
-    var onCancel: (() -> Void)?
+
+    // Callbacks
+    var onSelect:           ((CGRect) -> Void)?
+    var onCancel:           (() -> Void)?
+    var onSelectionChanged: ((CGRect?) -> Void)?
+
+    /// Active aspect constraint.  Updated by the presenter when the user picks
+    /// a chip; the view re-fits the existing selection and locks future drags.
+    var aspect: CropAspectRatio = .freeform
+
+    // MARK: Internal state
 
     private enum DragMode {
         case none
@@ -130,21 +219,19 @@ private final class RecordingAreaSelectionView: NSView {
         case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
     }
 
-    private let pixelScale: CGSize
-    private let minimumSize: CGFloat = 16
-    private let handleLength: CGFloat = 10
-    private let handleHitPadding: CGFloat = 6
+    private let pixelScale:     CGSize
+    private let minimumSize:    CGFloat = 16
+    private let handleLength:   CGFloat = 10
+    private let handleHitPad:   CGFloat = 6
 
-    private var selection: CGRect?
-    private var drawStart: CGPoint?
-    private var drawCurrent: CGPoint?
-    private var dragMode: DragMode = .none
-    private var moveOffset: CGSize = .zero
-    private var resizeAnchor: CGRect = .zero
+    private var selection:    CGRect?
+    private var drawStart:    CGPoint?
+    private var drawCurrent:  CGPoint?
+    private var dragMode:     DragMode = .none
+    private var moveOffset:   CGSize   = .zero
+    private var resizeAnchor: CGRect   = .zero
 
-    override var acceptsFirstResponder: Bool {
-        true
-    }
+    override var acceptsFirstResponder: Bool { true }
 
     init(frame frameRect: NSRect, pixelScale: CGSize) {
         self.pixelScale = pixelScale
@@ -152,31 +239,75 @@ private final class RecordingAreaSelectionView: NSView {
         wantsLayer = true
     }
 
-    required init?(coder: NSCoder) {
-        nil
+    required init?(coder: NSCoder) { nil }
+
+    // MARK: - Aspect
+
+    /// Apply a new aspect constraint and re-fit the existing selection (if any).
+    func applyAspect(_ newAspect: CropAspectRatio) {
+        aspect = newAspect
+        guard let current = selection,
+              let ratio   = newAspect.pixelRatio(imageSize: .zero) else {
+            needsDisplay = true
+            return
+        }
+        let cw = current.width
+        let ch = current.height
+        var w: CGFloat
+        var h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+        // Clamp to screen bounds
+        if w > bounds.width  { w = bounds.width;  h = w / ratio }
+        if h > bounds.height { h = bounds.height; w = h * ratio }
+        selection = CGRect(
+            x: min(max(current.midX - w / 2, bounds.minX), bounds.maxX - w),
+            y: min(max(current.midY - h / 2, bounds.minY), bounds.maxY - h),
+            width: w, height: h
+        )
+        onSelectionChanged?(selection)
+        needsDisplay = true
+        window?.invalidateCursorRects(for: self)
     }
 
     // MARK: - Active rect
-
-    private var draftRect: CGRect? {
-        guard let drawStart, let drawCurrent else { return nil }
-
-        return CGRect(
-            x: min(drawStart.x, drawCurrent.x),
-            y: min(drawStart.y, drawCurrent.y),
-            width: abs(drawStart.x - drawCurrent.x),
-            height: abs(drawStart.y - drawCurrent.y)
-        )
-    }
 
     private var isDrawing: Bool {
         if case .drawing = dragMode { return true }
         return false
     }
 
-    private var activeRect: CGRect? {
-        isDrawing ? draftRect : selection
+    private var draftRect: CGRect? {
+        guard let drawStart, let drawCurrent else { return nil }
+        let dx = drawCurrent.x - drawStart.x
+        let dy = drawCurrent.y - drawStart.y
+
+        guard let ratio = aspect.pixelRatio(imageSize: .zero) else {
+            // Freeform
+            return CGRect(
+                x: min(drawStart.x, drawCurrent.x),
+                y: min(drawStart.y, drawCurrent.y),
+                width:  abs(dx),
+                height: abs(dy)
+            )
+        }
+
+        // Aspect-locked: shrink the over-constrained dimension so the rect
+        // always fits within the drag extent.
+        let cw = abs(dx), ch = abs(dy)
+        let w: CGFloat
+        let h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+
+        return CGRect(
+            x: dx >= 0 ? drawStart.x : drawStart.x - w,
+            y: dy >= 0 ? drawStart.y : drawStart.y - h,
+            width: w, height: h
+        )
     }
+
+    private var activeRect: CGRect? { isDrawing ? draftRect : selection }
 
     // MARK: - Drawing
 
@@ -200,51 +331,22 @@ private final class RecordingAreaSelectionView: NSView {
             }
         }
 
-        if !isDrawing {
-            drawHint()
+        // Hint: only before the first selection; toolbar handles the rest.
+        if !isDrawing, selection == nil {
+            drawHint("Drag to select an area")
         }
-    }
-
-    private func drawHint() {
-        let text = selection == nil
-            ? "Drag to select an area    Esc to cancel"
-            : "Return to record    Drag to adjust    Esc to cancel"
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 13, weight: .medium),
-            .foregroundColor: NSColor.white
-        ]
-        let attributedHint = NSAttributedString(string: text, attributes: attributes)
-        let textSize = attributedHint.size()
-        let padding = CGSize(width: 14, height: 9)
-        let badgeSize = CGSize(width: textSize.width + padding.width * 2, height: textSize.height + padding.height * 2)
-        let badgeRect = CGRect(
-            x: bounds.midX - badgeSize.width / 2,
-            y: bounds.maxY - badgeSize.height - 28,
-            width: badgeSize.width,
-            height: badgeSize.height
-        )
-
-        NSColor.black.withAlphaComponent(0.62).setFill()
-        NSBezierPath(roundedRect: badgeRect, xRadius: 9, yRadius: 9).fill()
-
-        attributedHint.draw(
-            at: CGPoint(
-                x: badgeRect.minX + padding.width,
-                y: badgeRect.minY + padding.height
-            )
-        )
     }
 
     private func drawHandles(for rect: CGRect) {
         for handle in Handle.allCases {
             let center = handlePoint(handle, in: rect)
-            let square = CGRect(
+            let sq = CGRect(
                 x: center.x - handleLength / 2,
                 y: center.y - handleLength / 2,
-                width: handleLength,
+                width:  handleLength,
                 height: handleLength
             )
-            let path = NSBezierPath(roundedRect: square, xRadius: 2, yRadius: 2)
+            let path = NSBezierPath(roundedRect: sq, xRadius: 2, yRadius: 2)
             NSColor.white.setFill()
             path.fill()
             NSColor.black.withAlphaComponent(0.55).setStroke()
@@ -253,78 +355,108 @@ private final class RecordingAreaSelectionView: NSView {
         }
     }
 
-    // MARK: - Mouse
-
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        true
+    private func drawHint(_ text: String) {
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font:            NSFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: NSColor.white
+        ]
+        let str      = NSAttributedString(string: text, attributes: attrs)
+        let textSize = str.size()
+        let pad      = CGSize(width: 14, height: 9)
+        let badgeSize = CGSize(
+            width:  textSize.width  + pad.width  * 2,
+            height: textSize.height + pad.height * 2
+        )
+        let badgeRect = CGRect(
+            x: bounds.midX - badgeSize.width / 2,
+            y: bounds.maxY - badgeSize.height - 28,
+            width:  badgeSize.width,
+            height: badgeSize.height
+        )
+        NSColor.black.withAlphaComponent(0.62).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 9, yRadius: 9).fill()
+        str.draw(at: CGPoint(
+            x: badgeRect.minX + pad.width,
+            y: badgeRect.minY + pad.height
+        ))
     }
+
+    // MARK: - Mouse events
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
 
-        if let selection {
-            if event.clickCount >= 2, selection.contains(point) {
-                commitSelection()
+        if let sel = selection {
+            // Double-click inside → commit
+            if event.clickCount >= 2, sel.contains(point) {
+                commitSelection(); return
+            }
+            // Hit-test a resize handle
+            if let handle = handle(at: point, in: sel) {
+                dragMode     = .resizing(handle)
+                resizeAnchor = sel
                 return
             }
-            if let handle = handle(at: point, in: selection) {
-                dragMode = .resizing(handle)
-                resizeAnchor = selection
-                return
-            }
-            if selection.contains(point) {
-                dragMode = .moving
-                moveOffset = CGSize(width: point.x - selection.minX, height: point.y - selection.minY)
+            // Inside body → move
+            if sel.contains(point) {
+                dragMode   = .moving
+                moveOffset = CGSize(
+                    width:  point.x - sel.minX,
+                    height: point.y - sel.minY
+                )
                 NSCursor.closedHand.set()
                 return
             }
         }
 
-        dragMode = .drawing
+        // Outside (or no selection) → start a new draw
+        dragMode  = .drawing
         selection = nil
-        drawStart = point
+        onSelectionChanged?(nil)
+        drawStart   = point
         drawCurrent = point
         needsDisplay = true
     }
 
     override func mouseDragged(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-
         switch dragMode {
         case .drawing:
             drawCurrent = point
         case .moving:
-            if let current = selection {
-                var moved = current
-                moved.origin = CGPoint(
-                    x: point.x - moveOffset.width,
-                    y: point.y - moveOffset.height
-                )
-                selection = clampToBounds(moved)
-            }
+            guard let cur = selection else { break }
+            var moved = cur
+            moved.origin = CGPoint(
+                x: point.x - moveOffset.width,
+                y: point.y - moveOffset.height
+            )
+            selection = clampToBounds(moved)
+            onSelectionChanged?(selection)
         case .resizing(let handle):
             selection = resizedRect(anchor: resizeAnchor, handle: handle, to: point)
+            onSelectionChanged?(selection)
         case .none:
             break
         }
-
         needsDisplay = true
     }
 
     override func mouseUp(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-
         if case .drawing = dragMode {
             drawCurrent = point
-            if let rect = draftRect, rect.width >= minimumSize, rect.height >= minimumSize {
+            if let rect = draftRect,
+               rect.width >= minimumSize, rect.height >= minimumSize {
                 selection = clampToBounds(rect)
             } else {
                 selection = nil
             }
-            drawStart = nil
+            drawStart   = nil
             drawCurrent = nil
+            onSelectionChanged?(selection)
         }
-
         dragMode = .none
         needsDisplay = true
         window?.invalidateCursorRects(for: self)
@@ -332,12 +464,9 @@ private final class RecordingAreaSelectionView: NSView {
 
     override func keyDown(with event: NSEvent) {
         switch event.keyCode {
-        case 53:            // Escape
-            onCancel?()
-        case 36, 76:        // Return / keypad Enter
-            commitSelection()
-        default:
-            super.keyDown(with: event)
+        case 53:       onCancel?()        // Esc
+        case 36, 76:   commitSelection()  // Return / keypad Enter
+        default:       super.keyDown(with: event)
         }
     }
 
@@ -346,7 +475,7 @@ private final class RecordingAreaSelectionView: NSView {
         onSelect?(selection)
     }
 
-    // MARK: - Geometry
+    // MARK: - Geometry helpers
 
     private func handlePoint(_ handle: Handle, in rect: CGRect) -> CGPoint {
         switch handle {
@@ -362,57 +491,112 @@ private final class RecordingAreaSelectionView: NSView {
     }
 
     private func handleHitRect(_ handle: Handle, in rect: CGRect) -> CGRect {
-        let center = handlePoint(handle, in: rect)
-        let reach = handleLength / 2 + handleHitPadding
-        return CGRect(
-            x: center.x - reach,
-            y: center.y - reach,
-            width: reach * 2,
-            height: reach * 2
-        )
+        let c     = handlePoint(handle, in: rect)
+        let reach = handleLength / 2 + handleHitPad
+        return CGRect(x: c.x - reach, y: c.y - reach, width: reach * 2, height: reach * 2)
     }
 
     private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
         Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
     }
 
-    private func resizedRect(anchor: CGRect, handle: Handle, to rawPoint: CGPoint) -> CGRect {
-        var minX = anchor.minX
-        var maxX = anchor.maxX
-        var minY = anchor.minY
-        var maxY = anchor.maxY
+    private func resizedRect(anchor: CGRect, handle: Handle, to raw: CGPoint) -> CGRect {
+        let ratio = aspect.pixelRatio(imageSize: .zero)
+        let px = max(bounds.minX, min(raw.x, bounds.maxX))
+        let py = max(bounds.minY, min(raw.y, bounds.maxY))
+        let p  = CGPoint(x: px, y: py)
 
-        let px = max(bounds.minX, min(rawPoint.x, bounds.maxX))
-        let py = max(bounds.minY, min(rawPoint.y, bounds.maxY))
-
+        // Corner handles: aspect-locked when a preset is active.
         switch handle {
-        case .left, .topLeft, .bottomLeft:
-            minX = min(px, anchor.maxX - minimumSize)
-        case .right, .topRight, .bottomRight:
-            maxX = max(px, anchor.minX + minimumSize)
+        case .topLeft:
+            if let r = ratio {
+                return aspectLockedCorner(
+                    anchorX: anchor.maxX, anchorY: anchor.minY,
+                    signX: -1, signY: +1, to: p, ratio: r)
+            }
+        case .topRight:
+            if let r = ratio {
+                return aspectLockedCorner(
+                    anchorX: anchor.minX, anchorY: anchor.minY,
+                    signX: +1, signY: +1, to: p, ratio: r)
+            }
+        case .bottomLeft:
+            if let r = ratio {
+                return aspectLockedCorner(
+                    anchorX: anchor.maxX, anchorY: anchor.maxY,
+                    signX: -1, signY: -1, to: p, ratio: r)
+            }
+        case .bottomRight:
+            if let r = ratio {
+                return aspectLockedCorner(
+                    anchorX: anchor.minX, anchorY: anchor.maxY,
+                    signX: +1, signY: -1, to: p, ratio: r)
+            }
         default:
             break
         }
 
+        // Edge handles (or freeform corners): unconstrained.
+        var minX = anchor.minX, maxX = anchor.maxX
+        var minY = anchor.minY, maxY = anchor.maxY
+
         switch handle {
-        case .bottom, .bottomLeft, .bottomRight:
-            minY = min(py, anchor.maxY - minimumSize)
-        case .top, .topLeft, .topRight:
-            maxY = max(py, anchor.minY + minimumSize)
-        default:
-            break
+        case .left,        .topLeft,     .bottomLeft:  minX = min(px, anchor.maxX - minimumSize)
+        case .right,       .topRight,    .bottomRight: maxX = max(px, anchor.minX + minimumSize)
+        default: break
+        }
+        switch handle {
+        case .bottom,      .bottomLeft,  .bottomRight: minY = min(py, anchor.maxY - minimumSize)
+        case .top,         .topLeft,     .topRight:    maxY = max(py, anchor.minY + minimumSize)
+        default: break
         }
 
         return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
     }
 
+    /// Resize a corner handle while locking to `ratio` (width ÷ height).
+    ///
+    /// - Parameters:
+    ///   - anchorX/Y: The fixed opposite corner (NSView y-up coordinates).
+    ///   - signX:     +1 = drag grows rightward, −1 = leftward.
+    ///   - signY:     +1 = drag grows upward,    −1 = downward.
+    private func aspectLockedCorner(
+        anchorX: CGFloat, anchorY: CGFloat,
+        signX: CGFloat,   signY: CGFloat,
+        to point: CGPoint,
+        ratio: CGFloat
+    ) -> CGRect {
+        let cw = max((point.x - anchorX) * signX, minimumSize)
+        let ch = max((point.y - anchorY) * signY, minimumSize)
+
+        var w: CGFloat
+        var h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+
+        // Clamp to screen bounds while preserving ratio
+        let maxW = signX > 0 ? bounds.maxX - anchorX : anchorX - bounds.minX
+        let maxH = signY > 0 ? bounds.maxY - anchorY : anchorY - bounds.minY
+        if w > maxW { w = maxW; h = w / ratio }
+        if h > maxH { h = maxH; w = h * ratio }
+        w = max(w, minimumSize)
+        h = max(h, minimumSize)
+
+        return CGRect(
+            x:      signX > 0 ? anchorX      : anchorX - w,
+            y:      signY > 0 ? anchorY      : anchorY - h,
+            width:  w,
+            height: h
+        )
+    }
+
     private func clampToBounds(_ rect: CGRect) -> CGRect {
-        var result = rect
-        result.size.width = min(result.size.width, bounds.width)
-        result.size.height = min(result.size.height, bounds.height)
-        result.origin.x = max(bounds.minX, min(result.origin.x, bounds.maxX - result.width))
-        result.origin.y = max(bounds.minY, min(result.origin.y, bounds.maxY - result.height))
-        return result
+        var r = rect
+        r.size.width  = min(r.size.width,  bounds.width)
+        r.size.height = min(r.size.height, bounds.height)
+        r.origin.x    = max(bounds.minX, min(r.origin.x, bounds.maxX - r.width))
+        r.origin.y    = max(bounds.minY, min(r.origin.y, bounds.maxY - r.height))
+        return r
     }
 
     // MARK: - Cursor
@@ -420,67 +604,54 @@ private final class RecordingAreaSelectionView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.invalidateCursorRects(for: self)
-        if window != nil {
-            NSCursor.annotationPlus.set()
-        }
+        if window != nil { NSCursor.annotationPlus.set() }
     }
 
     override func resetCursorRects() {
         addCursorRect(bounds, cursor: .annotationPlus)
-
         guard let selection, !isDrawing else { return }
-
         addCursorRect(selection, cursor: .openHand)
         for handle in Handle.allCases {
-            addCursorRect(handleHitRect(handle, in: selection), cursor: cursor(for: handle))
+            addCursorRect(handleHitRect(handle, in: selection), cursor: cursorFor(handle))
         }
     }
 
-    private func cursor(for handle: Handle) -> NSCursor {
+    private func cursorFor(_ handle: Handle) -> NSCursor {
         switch handle {
-        case .left, .right:
-            return .resizeLeftRight
-        case .top, .bottom:
-            return .resizeUpDown
-        case .topLeft, .topRight, .bottomLeft, .bottomRight:
-            return .crosshair
+        case .left, .right:  return .resizeLeftRight
+        case .top, .bottom:  return .resizeUpDown
+        default:             return .crosshair
         }
     }
 
     // MARK: - Size badge
 
     private func drawSelectionSize(for rect: CGRect) {
-        let pixelWidth = Int((rect.width * pixelScale.width).rounded())
-        let pixelHeight = Int((rect.height * pixelScale.height).rounded())
-        let label = "\(pixelWidth) x \(pixelHeight)"
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold),
+        let pw = Int((rect.width  * pixelScale.width).rounded())
+        let ph = Int((rect.height * pixelScale.height).rounded())
+        let label = "\(pw) x \(ph)"
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font:            NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold),
             .foregroundColor: NSColor.white
         ]
-        let attributedLabel = NSAttributedString(string: label, attributes: attributes)
-        let textSize = attributedLabel.size()
-        let padding = CGSize(width: 10, height: 6)
-        let badgeSize = CGSize(width: textSize.width + padding.width * 2, height: textSize.height + padding.height * 2)
-        let badgeOrigin = badgeOrigin(for: rect, size: badgeSize)
-        let badgeRect = CGRect(origin: badgeOrigin, size: badgeSize)
+        let str      = NSAttributedString(string: label, attributes: attrs)
+        let textSize = str.size()
+        let pad      = CGSize(width: 10, height: 6)
+        let badgeSize = CGSize(
+            width:  textSize.width  + pad.width  * 2,
+            height: textSize.height + pad.height * 2
+        )
+        let origin    = badgeOrigin(for: rect, size: badgeSize)
+        let badgeRect = CGRect(origin: origin, size: badgeSize)
 
         NSColor.black.withAlphaComponent(0.72).setFill()
         NSBezierPath(roundedRect: badgeRect, xRadius: 7, yRadius: 7).fill()
-
-        attributedLabel.draw(
-            at: CGPoint(
-                x: badgeRect.minX + padding.width,
-                y: badgeRect.minY + padding.height
-            )
-        )
+        str.draw(at: CGPoint(x: badgeRect.minX + pad.width, y: badgeRect.minY + pad.height))
     }
 
     private func badgeOrigin(for rect: CGRect, size: CGSize) -> CGPoint {
         let preferred = CGPoint(x: rect.minX, y: rect.minY - size.height - 8)
-        if bounds.contains(CGRect(origin: preferred, size: size)) {
-            return preferred
-        }
-
+        if bounds.contains(CGRect(origin: preferred, size: size)) { return preferred }
         let fallbackY = min(rect.maxY + 8, bounds.maxY - size.height - 8)
         return CGPoint(
             x: min(max(rect.minX, bounds.minX + 8), bounds.maxX - size.width - 8),

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -92,7 +92,11 @@ final class RecordingAreaSelectionPresenter {
         installKeyMonitor()
         overlayPanel.makeKeyAndOrderFront(nil)
         overlayPanel.orderFrontRegardless()
-        toolbarPanel?.orderFrontRegardless()
+        // Attach toolbar as a child window so the window server keeps it above
+        // the overlay regardless of subsequent mouse interactions on the overlay.
+        if let tp = toolbarPanel {
+            overlayPanel.addChildWindow(tp, ordered: .above)
+        }
     }
 
     func cancel() {
@@ -108,7 +112,10 @@ final class RecordingAreaSelectionPresenter {
         model            = nil
         selectionView    = nil
         removeKeyMonitor()
-        toolbarPanel?.orderOut(nil)
+        if let tp = toolbarPanel {
+            panel?.removeChildWindow(tp)
+            tp.orderOut(nil)
+        }
         toolbarPanel = nil
         panel?.orderOut(nil)
         panel = nil

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -75,7 +75,6 @@ final class RecordingAreaSelectionPresenter {
         installKeyMonitor()
         panel.makeKeyAndOrderFront(nil)
         panel.orderFrontRegardless()
-        selectionView.beginSelectionCursorSession()
     }
 
     func cancel() {
@@ -87,7 +86,6 @@ final class RecordingAreaSelectionPresenter {
         self.completion = nil
         display = nil
         removeKeyMonitor()
-        (panel?.contentView as? RecordingAreaSelectionView)?.endSelectionCursorSession()
         panel?.orderOut(nil)
         panel = nil
         completion?(rect)
@@ -121,10 +119,28 @@ private final class RecordingAreaSelectionView: NSView {
     var onSelect: ((CGRect) -> Void)?
     var onCancel: (() -> Void)?
 
-    private var startPoint: CGPoint?
-    private var currentPoint: CGPoint?
+    private enum DragMode {
+        case none
+        case drawing
+        case moving
+        case resizing(Handle)
+    }
+
+    private enum Handle: CaseIterable {
+        case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
+    }
+
     private let pixelScale: CGSize
-    private var didPushSelectionCursor = false
+    private let minimumSize: CGFloat = 16
+    private let handleLength: CGFloat = 10
+    private let handleHitPadding: CGFloat = 6
+
+    private var selection: CGRect?
+    private var drawStart: CGPoint?
+    private var drawCurrent: CGPoint?
+    private var dragMode: DragMode = .none
+    private var moveOffset: CGSize = .zero
+    private var resizeAnchor: CGRect = .zero
 
     override var acceptsFirstResponder: Bool {
         true
@@ -140,95 +156,298 @@ private final class RecordingAreaSelectionView: NSView {
         nil
     }
 
-    deinit {
-        endSelectionCursorSession()
+    // MARK: - Active rect
+
+    private var draftRect: CGRect? {
+        guard let drawStart, let drawCurrent else { return nil }
+
+        return CGRect(
+            x: min(drawStart.x, drawCurrent.x),
+            y: min(drawStart.y, drawCurrent.y),
+            width: abs(drawStart.x - drawCurrent.x),
+            height: abs(drawStart.y - drawCurrent.y)
+        )
     }
+
+    private var isDrawing: Bool {
+        if case .drawing = dragMode { return true }
+        return false
+    }
+
+    private var activeRect: CGRect? {
+        isDrawing ? draftRect : selection
+    }
+
+    // MARK: - Drawing
 
     override func draw(_ dirtyRect: NSRect) {
         NSColor.black.withAlphaComponent(0.28).setFill()
         bounds.fill()
 
-        guard let selectionRect else { return }
+        if let rect = activeRect {
+            NSColor.clear.setFill()
+            rect.fill(using: .clear)
 
-        NSColor.clear.setFill()
-        selectionRect.fill(using: .clear)
+            NSColor.white.withAlphaComponent(0.96).setStroke()
+            let border = NSBezierPath(roundedRect: rect, xRadius: 4, yRadius: 4)
+            border.lineWidth = 2
+            border.stroke()
 
-        NSColor.white.withAlphaComponent(0.96).setStroke()
-        let border = NSBezierPath(roundedRect: selectionRect, xRadius: 4, yRadius: 4)
-        border.lineWidth = 2
-        border.stroke()
+            drawSelectionSize(for: rect)
 
-        drawSelectionSize(for: selectionRect)
+            if !isDrawing, selection != nil {
+                drawHandles(for: rect)
+            }
+        }
+
+        if !isDrawing {
+            drawHint()
+        }
     }
 
-    override func resetCursorRects() {
-        addCursorRect(bounds, cursor: .annotationPlus)
+    private func drawHint() {
+        let text = selection == nil
+            ? "Drag to select an area    Esc to cancel"
+            : "Return to record    Drag to adjust    Esc to cancel"
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: NSColor.white
+        ]
+        let attributedHint = NSAttributedString(string: text, attributes: attributes)
+        let textSize = attributedHint.size()
+        let padding = CGSize(width: 14, height: 9)
+        let badgeSize = CGSize(width: textSize.width + padding.width * 2, height: textSize.height + padding.height * 2)
+        let badgeRect = CGRect(
+            x: bounds.midX - badgeSize.width / 2,
+            y: bounds.maxY - badgeSize.height - 28,
+            width: badgeSize.width,
+            height: badgeSize.height
+        )
+
+        NSColor.black.withAlphaComponent(0.62).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 9, yRadius: 9).fill()
+
+        attributedHint.draw(
+            at: CGPoint(
+                x: badgeRect.minX + padding.width,
+                y: badgeRect.minY + padding.height
+            )
+        )
     }
+
+    private func drawHandles(for rect: CGRect) {
+        for handle in Handle.allCases {
+            let center = handlePoint(handle, in: rect)
+            let square = CGRect(
+                x: center.x - handleLength / 2,
+                y: center.y - handleLength / 2,
+                width: handleLength,
+                height: handleLength
+            )
+            let path = NSBezierPath(roundedRect: square, xRadius: 2, yRadius: 2)
+            NSColor.white.setFill()
+            path.fill()
+            NSColor.black.withAlphaComponent(0.55).setStroke()
+            path.lineWidth = 1
+            path.stroke()
+        }
+    }
+
+    // MARK: - Mouse
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if let selection {
+            if event.clickCount >= 2, selection.contains(point) {
+                commitSelection()
+                return
+            }
+            if let handle = handle(at: point, in: selection) {
+                dragMode = .resizing(handle)
+                resizeAnchor = selection
+                return
+            }
+            if selection.contains(point) {
+                dragMode = .moving
+                moveOffset = CGSize(width: point.x - selection.minX, height: point.y - selection.minY)
+                NSCursor.closedHand.set()
+                return
+            }
+        }
+
+        dragMode = .drawing
+        selection = nil
+        drawStart = point
+        drawCurrent = point
+        needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        switch dragMode {
+        case .drawing:
+            drawCurrent = point
+        case .moving:
+            if let current = selection {
+                var moved = current
+                moved.origin = CGPoint(
+                    x: point.x - moveOffset.width,
+                    y: point.y - moveOffset.height
+                )
+                selection = clampToBounds(moved)
+            }
+        case .resizing(let handle):
+            selection = resizedRect(anchor: resizeAnchor, handle: handle, to: point)
+        case .none:
+            break
+        }
+
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if case .drawing = dragMode {
+            drawCurrent = point
+            if let rect = draftRect, rect.width >= minimumSize, rect.height >= minimumSize {
+                selection = clampToBounds(rect)
+            } else {
+                selection = nil
+            }
+            drawStart = nil
+            drawCurrent = nil
+        }
+
+        dragMode = .none
+        needsDisplay = true
+        window?.invalidateCursorRects(for: self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 53:            // Escape
+            onCancel?()
+        case 36, 76:        // Return / keypad Enter
+            commitSelection()
+        default:
+            super.keyDown(with: event)
+        }
+    }
+
+    private func commitSelection() {
+        guard let selection else { return }
+        onSelect?(selection)
+    }
+
+    // MARK: - Geometry
+
+    private func handlePoint(_ handle: Handle, in rect: CGRect) -> CGPoint {
+        switch handle {
+        case .topLeft:     return CGPoint(x: rect.minX, y: rect.maxY)
+        case .top:         return CGPoint(x: rect.midX, y: rect.maxY)
+        case .topRight:    return CGPoint(x: rect.maxX, y: rect.maxY)
+        case .right:       return CGPoint(x: rect.maxX, y: rect.midY)
+        case .bottomRight: return CGPoint(x: rect.maxX, y: rect.minY)
+        case .bottom:      return CGPoint(x: rect.midX, y: rect.minY)
+        case .bottomLeft:  return CGPoint(x: rect.minX, y: rect.minY)
+        case .left:        return CGPoint(x: rect.minX, y: rect.midY)
+        }
+    }
+
+    private func handleHitRect(_ handle: Handle, in rect: CGRect) -> CGRect {
+        let center = handlePoint(handle, in: rect)
+        let reach = handleLength / 2 + handleHitPadding
+        return CGRect(
+            x: center.x - reach,
+            y: center.y - reach,
+            width: reach * 2,
+            height: reach * 2
+        )
+    }
+
+    private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
+        Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
+    }
+
+    private func resizedRect(anchor: CGRect, handle: Handle, to rawPoint: CGPoint) -> CGRect {
+        var minX = anchor.minX
+        var maxX = anchor.maxX
+        var minY = anchor.minY
+        var maxY = anchor.maxY
+
+        let px = max(bounds.minX, min(rawPoint.x, bounds.maxX))
+        let py = max(bounds.minY, min(rawPoint.y, bounds.maxY))
+
+        switch handle {
+        case .left, .topLeft, .bottomLeft:
+            minX = min(px, anchor.maxX - minimumSize)
+        case .right, .topRight, .bottomRight:
+            maxX = max(px, anchor.minX + minimumSize)
+        default:
+            break
+        }
+
+        switch handle {
+        case .bottom, .bottomLeft, .bottomRight:
+            minY = min(py, anchor.maxY - minimumSize)
+        case .top, .topLeft, .topRight:
+            maxY = max(py, anchor.minY + minimumSize)
+        default:
+            break
+        }
+
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    private func clampToBounds(_ rect: CGRect) -> CGRect {
+        var result = rect
+        result.size.width = min(result.size.width, bounds.width)
+        result.size.height = min(result.size.height, bounds.height)
+        result.origin.x = max(bounds.minX, min(result.origin.x, bounds.maxX - result.width))
+        result.origin.y = max(bounds.minY, min(result.origin.y, bounds.maxY - result.height))
+        return result
+    }
+
+    // MARK: - Cursor
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.invalidateCursorRects(for: self)
         if window != nil {
-            beginSelectionCursorSession()
-        } else {
-            endSelectionCursorSession()
-        }
-    }
-
-    override func cursorUpdate(with event: NSEvent) {
-        beginSelectionCursorSession()
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        startPoint = point
-        currentPoint = point
-        needsDisplay = true
-    }
-
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        beginSelectionCursorSession()
-        return true
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-        currentPoint = convert(event.locationInWindow, from: nil)
-        needsDisplay = true
-    }
-
-    override func mouseUp(with event: NSEvent) {
-        currentPoint = convert(event.locationInWindow, from: nil)
-        guard let rect = selectionRect, rect.width >= 16, rect.height >= 16 else {
-            onCancel?()
-            return
-        }
-
-        onSelect?(rect)
-    }
-
-    override func keyDown(with event: NSEvent) {
-        if event.keyCode == 53 {
-            onCancel?()
-        } else {
-            super.keyDown(with: event)
-        }
-    }
-
-    func beginSelectionCursorSession() {
-        if didPushSelectionCursor {
             NSCursor.annotationPlus.set()
-        } else {
-            NSCursor.annotationPlus.push()
-            didPushSelectionCursor = true
         }
     }
 
-    func endSelectionCursorSession() {
-        guard didPushSelectionCursor else { return }
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .annotationPlus)
 
-        NSCursor.pop()
-        didPushSelectionCursor = false
+        guard let selection, !isDrawing else { return }
+
+        addCursorRect(selection, cursor: .openHand)
+        for handle in Handle.allCases {
+            addCursorRect(handleHitRect(handle, in: selection), cursor: cursor(for: handle))
+        }
     }
+
+    private func cursor(for handle: Handle) -> NSCursor {
+        switch handle {
+        case .left, .right:
+            return .resizeLeftRight
+        case .top, .bottom:
+            return .resizeUpDown
+        case .topLeft, .topRight, .bottomLeft, .bottomRight:
+            return .crosshair
+        }
+    }
+
+    // MARK: - Size badge
 
     private func drawSelectionSize(for rect: CGRect) {
         let pixelWidth = Int((rect.width * pixelScale.width).rounded())
@@ -266,17 +485,6 @@ private final class RecordingAreaSelectionView: NSView {
         return CGPoint(
             x: min(max(rect.minX, bounds.minX + 8), bounds.maxX - size.width - 8),
             y: max(fallbackY, bounds.minY + 8)
-        )
-    }
-
-    private var selectionRect: CGRect? {
-        guard let startPoint, let currentPoint else { return nil }
-
-        return CGRect(
-            x: min(startPoint.x, currentPoint.x),
-            y: min(startPoint.y, currentPoint.y),
-            width: abs(startPoint.x - currentPoint.x),
-            height: abs(startPoint.y - currentPoint.y)
         )
     }
 }

--- a/Screendrop/RecordingAreaSelectionPresenter.swift
+++ b/Screendrop/RecordingAreaSelectionPresenter.swift
@@ -145,9 +145,8 @@ final class RecordingAreaSelectionPresenter {
             model:          model,
             onStart:        { [weak self] in self?.finishWithModelSelection() },
             onCancel:       { [weak self] in self?.cancel() },
-            onAspectChange: { [weak self] aspect in
-                self?.selectionView?.applyAspect(aspect)
-            }
+            onAspectChange: { [weak self] aspect in self?.selectionView?.applyAspect(aspect) },
+            onModeChange:   { _ in }   // mode switching handled by RecordingSetupPresenter (PR 3)
         )
 
         let hosting     = NSHostingView(rootView: toolbarView)

--- a/Screendrop/RecordingSetupModel.swift
+++ b/Screendrop/RecordingSetupModel.swift
@@ -1,0 +1,40 @@
+//
+//  RecordingSetupModel.swift
+//  Screendrop
+//
+//  Shared state between the area-selection overlay and the recording setup
+//  toolbar. Both surfaces read and write through this model; the presenter
+//  is the single owner that keeps them in sync.
+//
+
+import CoreGraphics
+import Observation
+
+@MainActor
+@Observable
+final class RecordingSetupModel {
+
+    /// The active aspect-ratio constraint.  `.freeform` means unconstrained.
+    var aspect: CropAspectRatio = .freeform
+
+    /// The committed selection rectangle in overlay-panel-local coordinates.
+    /// `nil` until the user draws a region; the Start button stays disabled
+    /// until this is set.
+    var selection: CGRect?
+
+    /// Point-to-pixel scale for the target display (used to show pixel dimensions).
+    let pixelScale: CGSize
+
+    /// Live pixel dimensions of the current selection, or `nil` when none.
+    var pixelSize: CGSize? {
+        guard let rect = selection else { return nil }
+        return CGSize(
+            width:  (rect.width  * pixelScale.width).rounded(),
+            height: (rect.height * pixelScale.height).rounded()
+        )
+    }
+
+    init(pixelScale: CGSize) {
+        self.pixelScale = pixelScale
+    }
+}

--- a/Screendrop/RecordingSetupModel.swift
+++ b/Screendrop/RecordingSetupModel.swift
@@ -9,15 +9,12 @@
 
 import CoreGraphics
 import Observation
-import ScreenCaptureKit
-
 // MARK: - Mode
 
-/// The three capture modes available in the recording setup HUD.
+/// Capture modes available in the recording setup HUD.
 enum RecordingSetupMode: String, CaseIterable, Identifiable {
     case fullscreen
     case area
-    case window
 
     var id: String { rawValue }
 
@@ -25,7 +22,6 @@ enum RecordingSetupMode: String, CaseIterable, Identifiable {
         switch self {
         case .fullscreen: "Full Screen"
         case .area:       "Area"
-        case .window:     "Window"
         }
     }
 }
@@ -51,11 +47,6 @@ final class RecordingSetupModel {
     /// Active aspect-ratio constraint for Area mode.
     var aspect: CropAspectRatio = .freeform
 
-    // MARK: Window
-
-    /// Window the user has locked onto (Window mode).
-    var selectedWindow: SCWindow?
-
     // MARK: Display
 
     /// Point-to-pixel scale for the target display (used to show W×H).
@@ -77,7 +68,6 @@ final class RecordingSetupModel {
         switch mode {
         case .fullscreen: return true
         case .area:       return selection != nil
-        case .window:     return selectedWindow != nil
         }
     }
 

--- a/Screendrop/RecordingSetupModel.swift
+++ b/Screendrop/RecordingSetupModel.swift
@@ -9,29 +9,76 @@
 
 import CoreGraphics
 import Observation
+import ScreenCaptureKit
+
+// MARK: - Mode
+
+/// The three capture modes available in the recording setup HUD.
+enum RecordingSetupMode: String, CaseIterable, Identifiable {
+    case fullscreen
+    case area
+    case window
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .fullscreen: "Full Screen"
+        case .area:       "Area"
+        case .window:     "Window"
+        }
+    }
+}
+
+// MARK: - Model
 
 @MainActor
 @Observable
 final class RecordingSetupModel {
 
-    /// The active aspect-ratio constraint.  `.freeform` means unconstrained.
-    var aspect: CropAspectRatio = .freeform
+    // MARK: Mode
 
-    /// The committed selection rectangle in overlay-panel-local coordinates.
-    /// `nil` until the user draws a region; the Start button stays disabled
-    /// until this is set.
+    /// The active capture mode.  The toolbar mode picker writes this; the
+    /// overlay adapts its interaction accordingly.
+    var mode: RecordingSetupMode = .area
+
+    // MARK: Area
+
+    /// Committed selection rect (panel-local coordinates) for Area mode.
+    /// `nil` until the user completes a draw; drives the Start button.
     var selection: CGRect?
 
-    /// Point-to-pixel scale for the target display (used to show pixel dimensions).
+    /// Active aspect-ratio constraint for Area mode.
+    var aspect: CropAspectRatio = .freeform
+
+    // MARK: Window
+
+    /// Window the user has locked onto (Window mode).
+    var selectedWindow: SCWindow?
+
+    // MARK: Display
+
+    /// Point-to-pixel scale for the target display (used to show W×H).
     let pixelScale: CGSize
 
-    /// Live pixel dimensions of the current selection, or `nil` when none.
+    // MARK: Derived
+
+    /// Live pixel dimensions of the current area selection, or `nil` when none.
     var pixelSize: CGSize? {
         guard let rect = selection else { return nil }
         return CGSize(
             width:  (rect.width  * pixelScale.width).rounded(),
             height: (rect.height * pixelScale.height).rounded()
         )
+    }
+
+    /// Whether the Start button should be enabled for the current mode.
+    var canStart: Bool {
+        switch mode {
+        case .fullscreen: return true
+        case .area:       return selection != nil
+        case .window:     return selectedWindow != nil
+        }
     }
 
     init(pixelScale: CGSize) {

--- a/Screendrop/RecordingSetupPresenter.swift
+++ b/Screendrop/RecordingSetupPresenter.swift
@@ -40,7 +40,7 @@ final class RecordingSetupPresenter {
         Task {
             do {
                 let content  = try await ScreenRecordingCapture.availableContent()
-                let windows  = RecordingSourceCatalog.filteredWindows(from: content)
+                let windows  = RecordingSourceCatalog.pickableWindows(from: content)
                 guard let display = content.displays.first(where: { $0.displayID == displayID })
                                  ?? content.displays.first else { return }
                 guard let screen = ActiveDisplayResolver.screen(for: display.displayID)
@@ -229,7 +229,6 @@ private final class RecordingSetupOverlayView: NSView {
     private let windows:        [SCWindow]
     private var hoveredWindow:  SCWindow?
     private var lockedWindow:   SCWindow?
-    private var didConfirmWindow = false
 
     // Area mode
     var aspect: CropAspectRatio = .freeform
@@ -270,7 +269,6 @@ private final class RecordingSetupOverlayView: NSView {
         selection     = nil
         hoveredWindow = nil
         lockedWindow  = nil
-        didConfirmWindow = false
         drawStart     = nil
         drawCurrent   = nil
         dragMode      = .none
@@ -347,20 +345,35 @@ private final class RecordingSetupOverlayView: NSView {
     }
 
     private func drawWindowMode() {
-        let target = lockedWindow ?? hoveredWindow
-        guard let target else {
+        guard hoveredWindow != nil || lockedWindow != nil else {
             drawHint("Move over a window, then click to record it")
             return
         }
-        let vf = windowViewFrame(target)
+
+        if let lockedWindow {
+            drawWindowOutline(for: lockedWindow, selected: true)
+        }
+
+        if let hoveredWindow, hoveredWindow.windowID != lockedWindow?.windowID {
+            drawWindowOutline(for: hoveredWindow, selected: false)
+        }
+
+        if lockedWindow != nil {
+            drawHint("Click Start or press Return to record selected window")
+        } else {
+            drawHint("Click to select this window")
+        }
+    }
+
+    private func drawWindowOutline(for window: SCWindow, selected: Bool) {
+        let vf = windowViewFrame(window)
         NSColor.clear.setFill()
         vf.fill(using: .clear)
-        NSColor.white.withAlphaComponent(0.96).setStroke()
+        (selected ? NSColor.controlAccentColor : NSColor.white).withAlphaComponent(0.96).setStroke()
         let path = NSBezierPath(roundedRect: vf, xRadius: 4, yRadius: 4)
-        path.lineWidth = 2
+        path.lineWidth = selected ? 3 : 2
         path.stroke()
-        drawWindowLabel(for: target, near: vf)
-        drawHint("Click to record this window")
+        drawWindowLabel(for: window, near: vf, selected: selected)
     }
 
     /// Corners only when an aspect preset is active — edge handles would
@@ -404,8 +417,10 @@ private final class RecordingSetupOverlayView: NSView {
         str.draw(at: CGPoint(x: bRect.minX + pad.width, y: bRect.minY + pad.height))
     }
 
-    private func drawWindowLabel(for win: SCWindow, near rect: CGRect) {
-        let text  = RecordingSourceCatalog.windowTitle(win)
+    private func drawWindowLabel(for win: SCWindow, near rect: CGRect, selected: Bool = false) {
+        let text = selected
+            ? "Selected · \(RecordingSourceCatalog.windowTitle(win))"
+            : RecordingSourceCatalog.windowTitle(win)
         let attrs: [NSAttributedString.Key: Any] = [
             .font:            NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold),
             .foregroundColor: NSColor.white
@@ -426,7 +441,7 @@ private final class RecordingSetupOverlayView: NSView {
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func mouseMoved(with event: NSEvent) {
-        guard mode == .window, !didConfirmWindow else { return }
+        guard mode == .window else { return }
 
         // Hover is already proof the cursor is over the overlay. Re-key here
         // instead of only in mouseEntered because moving from the child toolbar
@@ -438,8 +453,11 @@ private final class RecordingSetupOverlayView: NSView {
         let newHover = windowAtPoint(point)
         if newHover?.windowID != hoveredWindow?.windowID {
             hoveredWindow = newHover
-            lockedWindow = newHover
-            onWindowSelected?(newHover)
+            if newHover == nil {
+                NSCursor.arrow.set()
+            } else {
+                NSCursor.pointingHand.set()
+            }
             needsDisplay  = true
             window?.invalidateCursorRects(for: self)
         }
@@ -451,11 +469,14 @@ private final class RecordingSetupOverlayView: NSView {
         case .fullscreen:
             confirm()
         case .window:
-            // Consistent with the native screenshot window picker
-            // (screencapture -w) and with Full Screen mode above: clicking a
-            // window selects and starts recording it immediately. Fall back to
-            // the hovered window so a tiny cursor jitter on click can't miss.
-            confirmWindow(windowAtPoint(point) ?? hoveredWindow ?? lockedWindow)
+            if let win = windowAtPoint(point) ?? hoveredWindow {
+                selectWindow(win)
+                if event.clickCount >= 2 {
+                    confirm()
+                }
+            } else {
+                selectWindow(nil)
+            }
         case .area:
             areaMouseDown(at: point, clickCount: event.clickCount)
         }
@@ -472,8 +493,11 @@ private final class RecordingSetupOverlayView: NSView {
         switch mode {
         case .window:
             // Fallback for first-mouse/key-window edge cases where AppKit
-            // delivers hover but swallows mouseDown.
-            confirmWindow(windowAtPoint(point) ?? hoveredWindow ?? lockedWindow)
+            // delivers hover but swallows mouseDown. Do not record here;
+            // just lock selection so Start becomes enabled.
+            if lockedWindow == nil {
+                selectWindow(windowAtPoint(point) ?? hoveredWindow)
+            }
         case .area:
             areaMouseUp(at: point)
         case .fullscreen:
@@ -498,14 +522,11 @@ private final class RecordingSetupOverlayView: NSView {
         }
     }
 
-    private func confirmWindow(_ window: SCWindow?) {
-        guard mode == .window, !didConfirmWindow, let window else { return }
-
-        didConfirmWindow = true
+    private func selectWindow(_ window: SCWindow?) {
         lockedWindow = window
-        hoveredWindow = nil
         onWindowSelected?(window)
-        confirm()
+        needsDisplay = true
+        self.window?.invalidateCursorRects(for: self)
     }
 
     // MARK: - Area mode helpers
@@ -701,13 +722,21 @@ private final class RecordingSetupOverlayView: NSView {
     }
 
     private func windowAtPoint(_ viewPoint: CGPoint) -> SCWindow? {
-        // Convert the view-local point → CG screen coordinates for comparison
-        // with SCWindow.frame.
-        let mainH       = NSScreen.screens.first?.frame.height ?? bounds.height
-        let panelOrigin = window?.frame.origin ?? .zero
-        let cgX = viewPoint.x + panelOrigin.x
-        let cgY = mainH - (viewPoint.y + panelOrigin.y)
-        return windows.first { $0.frame.contains(CGPoint(x: cgX, y: cgY)) }
+        // Use the same local AppKit frame for hit-testing that we use for
+        // drawing the highlight. This keeps the visible target and clickable
+        // target identical, and filters windows not meaningfully visible on
+        // this overlay/display.
+        windows.first { window in
+            let frame = windowViewFrame(window)
+            guard isVisibleWindowFrame(frame) else { return false }
+            return frame.contains(viewPoint)
+        }
+    }
+
+    private func isVisibleWindowFrame(_ frame: CGRect) -> Bool {
+        guard frame.intersects(bounds) else { return false }
+        let visible = frame.intersection(bounds)
+        return visible.width >= 32 && visible.height >= 32
     }
 
     // MARK: - Tracking / key
@@ -744,7 +773,8 @@ private final class RecordingSetupOverlayView: NSView {
         switch mode {
         case .fullscreen, .window:
             addCursorRect(bounds, cursor: .arrow)
-            if mode == .window, let target = hoveredWindow ?? lockedWindow {
+            if mode == .window, let target = hoveredWindow ?? lockedWindow,
+               isVisibleWindowFrame(windowViewFrame(target)) {
                 addCursorRect(windowViewFrame(target), cursor: .pointingHand)
             }
         case .area:

--- a/Screendrop/RecordingSetupPresenter.swift
+++ b/Screendrop/RecordingSetupPresenter.swift
@@ -106,7 +106,11 @@ final class RecordingSetupPresenter {
         installKeyMonitor()
         panel.makeKeyAndOrderFront(nil)
         panel.orderFrontRegardless()
-        toolbarPanel?.orderFrontRegardless()
+        // Child window relationship guarantees the toolbar is always above the
+        // overlay regardless of subsequent mouse interactions on the overlay.
+        if let tp = toolbarPanel {
+            panel.addChildWindow(tp, ordered: .above)
+        }
     }
 
     private func confirm() {
@@ -118,7 +122,11 @@ final class RecordingSetupPresenter {
 
     private func dismiss() {
         removeKeyMonitor()
-        toolbarPanel?.orderOut(nil); toolbarPanel = nil
+        if let tp = toolbarPanel {
+            overlayPanel?.removeChildWindow(tp)
+            tp.orderOut(nil)
+        }
+        toolbarPanel = nil
         overlayPanel?.orderOut(nil); overlayPanel = nil
         overlayView = nil
         model       = nil

--- a/Screendrop/RecordingSetupPresenter.swift
+++ b/Screendrop/RecordingSetupPresenter.swift
@@ -1,0 +1,720 @@
+//
+//  RecordingSetupPresenter.swift
+//  Screendrop
+//
+//  Unified entry point for the recording setup HUD (Full Screen / Area /
+//  Window).  Shows a full-screen selection overlay and a floating toolbar,
+//  then hands a resolved ScreenRecordingSource to ScreenRecordingManager.
+//
+//  Area mode geometry (drag, 8 handles, aspect lock) mirrors the logic in
+//  RecordingAreaSelectionView from RecordingAreaSelectionPresenter.  The
+//  duplication is intentional: RecordingAreaSelectionPresenter will be
+//  retired in a follow-up cleanup PR once all entry points route here.
+//
+
+import AppKit
+import ScreenCaptureKit
+import SwiftUI
+
+// MARK: - Presenter
+
+@MainActor
+final class RecordingSetupPresenter {
+    static let shared = RecordingSetupPresenter()
+
+    private var overlayPanel: RecordingSetupKeyPanel?
+    private var toolbarPanel: NSPanel?
+    private var overlayView:  RecordingSetupOverlayView?
+    private var model:        RecordingSetupModel?
+    private var display:      SCDisplay?
+    private var keyMonitor:   Any?
+
+    private init() {}
+
+    /// Resolve the active display, load window sources, and present the HUD.
+    func begin() {
+        // Don't interrupt an in-flight recording.
+        guard ScreenRecordingManager.shared.state == .idle else { return }
+
+        let displayID = ActiveDisplayResolver.activeDisplayID(preferPointer: false)
+        Task {
+            do {
+                let content  = try await ScreenRecordingCapture.availableContent()
+                let windows  = RecordingSourceCatalog.filteredWindows(from: content)
+                guard let display = content.displays.first(where: { $0.displayID == displayID })
+                                 ?? content.displays.first else { return }
+                guard let screen = ActiveDisplayResolver.screen(for: display.displayID)
+                                ?? NSScreen.main else { return }
+                show(display: display, windows: windows, screen: screen)
+            } catch {
+                // Screen recording permission denied or SCK unavailable — fail silently.
+            }
+        }
+    }
+
+    func cancel() { dismiss() }
+
+    // MARK: Private — lifecycle
+
+    private func show(display: SCDisplay, windows: [SCWindow], screen: NSScreen) {
+        dismiss()   // tear down any previous HUD
+
+        self.display = display
+
+        let pixelScale = CGSize(
+            width:  CGFloat(display.width)  / max(screen.frame.width,  1),
+            height: CGFloat(display.height) / max(screen.frame.height, 1)
+        )
+
+        let setupModel = RecordingSetupModel(pixelScale: pixelScale)
+        self.model = setupModel
+
+        // ── Overlay ────────────────────────────────────────────────────────
+        let panel = RecordingSetupKeyPanel(
+            contentRect: screen.frame,
+            styleMask:   [.borderless, .nonactivatingPanel],
+            backing:     .buffered,
+            defer:       false
+        )
+        panel.backgroundColor         = .clear
+        panel.isOpaque                = false
+        panel.hasShadow               = false
+        panel.level                   = .screenSaver
+        panel.collectionBehavior      = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.isReleasedWhenClosed    = false
+        panel.acceptsMouseMovedEvents = true
+        panel.sharingType             = .none
+
+        let ov = RecordingSetupOverlayView(
+            frame:      CGRect(origin: .zero, size: screen.frame.size),
+            pixelScale: pixelScale,
+            windows:    windows
+        )
+        ov.onConfirm          = { [weak self] in self?.confirm() }
+        ov.onCancel           = { [weak self] in self?.dismiss() }
+        ov.onSelectionChanged = { [weak setupModel] rect in setupModel?.selection = rect }
+        ov.onWindowSelected   = { [weak setupModel] win  in setupModel?.selectedWindow = win }
+
+        panel.contentView = ov
+        panel.makeFirstResponder(ov)
+        overlayPanel = panel
+        overlayView  = ov
+
+        // ── Toolbar ────────────────────────────────────────────────────────
+        toolbarPanel = makeToolbarPanel(screen: screen, model: setupModel)
+
+        installKeyMonitor()
+        panel.makeKeyAndOrderFront(nil)
+        panel.orderFrontRegardless()
+        toolbarPanel?.orderFrontRegardless()
+    }
+
+    private func confirm() {
+        guard let source = resolveSource() else { return }
+        let mgr = ScreenRecordingManager.shared
+        dismiss()
+        mgr.startRecording(source: source)
+    }
+
+    private func dismiss() {
+        removeKeyMonitor()
+        toolbarPanel?.orderOut(nil); toolbarPanel = nil
+        overlayPanel?.orderOut(nil); overlayPanel = nil
+        overlayView = nil
+        model       = nil
+        display     = nil
+    }
+
+    private func resolveSource() -> ScreenRecordingSource? {
+        guard let display, let model else { return nil }
+        switch model.mode {
+        case .fullscreen:
+            return ScreenRecordingSource(kind: .fullscreen(display))
+        case .area:
+            guard let rect = model.selection else { return nil }
+            return ScreenRecordingSource(kind: .area(display: display, rect: rect))
+        case .window:
+            guard let win = model.selectedWindow else { return nil }
+            return ScreenRecordingSource(kind: .window(win))
+        }
+    }
+
+    // MARK: Private — toolbar panel
+
+    private func makeToolbarPanel(screen: NSScreen, model: RecordingSetupModel) -> NSPanel {
+        let view = RecordingSetupToolbarView(
+            model:          model,
+            onStart:        { [weak self] in self?.confirm() },
+            onCancel:       { [weak self] in self?.dismiss() },
+            onAspectChange: { [weak self] aspect in self?.overlayView?.applyAspect(aspect) },
+            onModeChange:   { [weak self] mode  in self?.overlayView?.applyMode(mode) }
+        )
+
+        let hosting    = NSHostingView(rootView: view)
+        let idealSize  = hosting.fittingSize
+        let panelWidth = max(idealSize.width, 480)
+        let panelH     = idealSize.height > 0 ? idealSize.height : 72
+
+        let panel = NSPanel(
+            contentRect: CGRect(
+                x: screen.frame.midX - panelWidth / 2,
+                y: screen.frame.minY + 32,
+                width: panelWidth, height: panelH
+            ),
+            styleMask:   [.borderless, .nonactivatingPanel],
+            backing:     .buffered,
+            defer:       false
+        )
+        panel.backgroundColor         = .clear
+        panel.isOpaque                = false
+        panel.hasShadow               = false
+        panel.level                   = .screenSaver
+        panel.collectionBehavior      = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.isReleasedWhenClosed    = false
+        panel.sharingType             = .none
+        panel.contentView             = hosting
+        return panel
+    }
+
+    // MARK: Private — key monitor
+
+    private func installKeyMonitor() {
+        removeKeyMonitor()
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.keyCode == 53 else { return event }   // Esc
+            self?.dismiss()
+            return nil
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let km = keyMonitor { NSEvent.removeMonitor(km); keyMonitor = nil }
+    }
+}
+
+// MARK: - Key panel subclass
+
+private final class RecordingSetupKeyPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+// MARK: - Overlay view
+
+/// Full-screen overlay that handles all three recording modes.
+///
+/// Area mode geometry (drag, 8 handles, aspect-lock) is intentionally
+/// duplicated from `RecordingAreaSelectionView` and will be consolidated
+/// when `RecordingAreaSelectionPresenter` is retired.
+private final class RecordingSetupOverlayView: NSView {
+
+    // Callbacks
+    var onConfirm:          (() -> Void)?
+    var onCancel:           (() -> Void)?
+    var onSelectionChanged: ((CGRect?) -> Void)?
+    var onWindowSelected:   ((SCWindow?) -> Void)?
+
+    // MARK: State
+
+    private(set) var mode: RecordingSetupMode = .area
+
+    // Window mode
+    private let windows:        [SCWindow]
+    private var hoveredWindow:  SCWindow?
+    private var lockedWindow:   SCWindow?
+
+    // Area mode
+    var aspect: CropAspectRatio = .freeform
+
+    private enum DragMode { case none, drawing, moving, resizing(Handle) }
+    private enum Handle: CaseIterable {
+        case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
+    }
+
+    private let pixelScale:   CGSize
+    private let minimumSize:  CGFloat = 16
+    private let handleLength: CGFloat = 10
+    private let handleHitPad: CGFloat = 6
+
+    private var selection:    CGRect?
+    private var drawStart:    CGPoint?
+    private var drawCurrent:  CGPoint?
+    private var dragMode:     DragMode = .none
+    private var moveOffset:   CGSize   = .zero
+    private var resizeAnchor: CGRect   = .zero
+
+    override var acceptsFirstResponder: Bool { true }
+
+    init(frame: NSRect, pixelScale: CGSize, windows: [SCWindow]) {
+        self.pixelScale = pixelScale
+        self.windows    = windows
+        super.init(frame: frame)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    // MARK: - Mode + aspect switching
+
+    func applyMode(_ newMode: RecordingSetupMode) {
+        mode          = newMode
+        selection     = nil
+        hoveredWindow = nil
+        lockedWindow  = nil
+        drawStart     = nil
+        drawCurrent   = nil
+        dragMode      = .none
+        onSelectionChanged?(nil)
+        onWindowSelected?(nil)
+        needsDisplay = true
+        window?.invalidateCursorRects(for: self)
+    }
+
+    func applyAspect(_ newAspect: CropAspectRatio) {
+        aspect = newAspect
+        guard let cur = selection, let ratio = newAspect.pixelRatio(imageSize: .zero) else {
+            needsDisplay = true; return
+        }
+        let cw = cur.width, ch = cur.height
+        var w: CGFloat
+        var h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+        if w > bounds.width  { w = bounds.width;  h = w / ratio }
+        if h > bounds.height { h = bounds.height; w = h * ratio }
+        selection = CGRect(
+            x: min(max(cur.midX - w / 2, bounds.minX), bounds.maxX - w),
+            y: min(max(cur.midY - h / 2, bounds.minY), bounds.maxY - h),
+            width: w, height: h
+        )
+        onSelectionChanged?(selection)
+        needsDisplay = true
+        window?.invalidateCursorRects(for: self)
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.black.withAlphaComponent(0.28).setFill()
+        bounds.fill()
+
+        switch mode {
+        case .fullscreen: drawFullscreenMode()
+        case .area:       drawAreaMode()
+        case .window:     drawWindowMode()
+        }
+    }
+
+    private func drawFullscreenMode() {
+        let inset = bounds.insetBy(dx: 4, dy: 4)
+        NSColor.clear.setFill()
+        inset.fill(using: .clear)
+        NSColor.white.withAlphaComponent(0.9).setStroke()
+        let path = NSBezierPath(roundedRect: inset, xRadius: 6, yRadius: 6)
+        path.lineWidth = 2.5
+        path.stroke()
+        drawHint("Click anywhere or press Return to record full screen")
+    }
+
+    private func drawAreaMode() {
+        let isDrawing: Bool = { if case .drawing = dragMode { return true }; return false }()
+        let rect = isDrawing ? draftRect : selection
+
+        if let rect {
+            NSColor.clear.setFill()
+            rect.fill(using: .clear)
+            NSColor.white.withAlphaComponent(0.96).setStroke()
+            let border = NSBezierPath(roundedRect: rect, xRadius: 4, yRadius: 4)
+            border.lineWidth = 2
+            border.stroke()
+            drawSelectionSize(for: rect)
+            if !isDrawing, selection != nil { drawHandles(for: rect) }
+        }
+
+        if !isDrawing, selection == nil {
+            drawHint("Drag to select an area")
+        }
+    }
+
+    private func drawWindowMode() {
+        let target = lockedWindow ?? hoveredWindow
+        guard let target else {
+            drawHint("Hover over a window to select it")
+            return
+        }
+        let vf = windowViewFrame(target)
+        NSColor.clear.setFill()
+        vf.fill(using: .clear)
+        NSColor.white.withAlphaComponent(0.96).setStroke()
+        let path = NSBezierPath(roundedRect: vf, xRadius: 4, yRadius: 4)
+        path.lineWidth = 2
+        path.stroke()
+        drawWindowLabel(for: target, near: vf)
+        if lockedWindow != nil {
+            drawHint("Press Return or click Start to record")
+        }
+    }
+
+    private func drawHandles(for rect: CGRect) {
+        for handle in Handle.allCases {
+            let center = handlePoint(handle, in: rect)
+            let sq = CGRect(
+                x: center.x - handleLength / 2, y: center.y - handleLength / 2,
+                width: handleLength, height: handleLength
+            )
+            let path = NSBezierPath(roundedRect: sq, xRadius: 2, yRadius: 2)
+            NSColor.white.setFill(); path.fill()
+            NSColor.black.withAlphaComponent(0.55).setStroke()
+            path.lineWidth = 1; path.stroke()
+        }
+    }
+
+    private func drawHint(_ text: String) {
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font:            NSFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: NSColor.white
+        ]
+        let str      = NSAttributedString(string: text, attributes: attrs)
+        let textSize = str.size()
+        let pad      = CGSize(width: 14, height: 9)
+        let bSize    = CGSize(width: textSize.width + pad.width * 2, height: textSize.height + pad.height * 2)
+        let bRect    = CGRect(
+            x: bounds.midX - bSize.width / 2,
+            y: bounds.maxY - bSize.height - 28,
+            width: bSize.width, height: bSize.height
+        )
+        NSColor.black.withAlphaComponent(0.62).setFill()
+        NSBezierPath(roundedRect: bRect, xRadius: 9, yRadius: 9).fill()
+        str.draw(at: CGPoint(x: bRect.minX + pad.width, y: bRect.minY + pad.height))
+    }
+
+    private func drawWindowLabel(for win: SCWindow, near rect: CGRect) {
+        let text  = RecordingSourceCatalog.windowTitle(win)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font:            NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold),
+            .foregroundColor: NSColor.white
+        ]
+        let str      = NSAttributedString(string: text, attributes: attrs)
+        let textSize = str.size()
+        let pad      = CGSize(width: 10, height: 6)
+        let bSize    = CGSize(width: textSize.width + pad.width * 2, height: textSize.height + pad.height * 2)
+        let origin   = badgeOrigin(for: rect, size: bSize)
+        let bRect    = CGRect(origin: origin, size: bSize)
+        NSColor.black.withAlphaComponent(0.72).setFill()
+        NSBezierPath(roundedRect: bRect, xRadius: 7, yRadius: 7).fill()
+        str.draw(at: CGPoint(x: bRect.minX + pad.width, y: bRect.minY + pad.height))
+    }
+
+    // MARK: - Mouse events
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseMoved(with event: NSEvent) {
+        guard mode == .window, lockedWindow == nil else { return }
+        let point    = convert(event.locationInWindow, from: nil)
+        let newHover = windowAtPoint(point)
+        if newHover?.windowID != hoveredWindow?.windowID {
+            hoveredWindow = newHover
+            needsDisplay  = true
+        }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        switch mode {
+        case .fullscreen:
+            confirm()
+        case .window:
+            if let win = windowAtPoint(point) {
+                if event.clickCount >= 2, win.windowID == lockedWindow?.windowID {
+                    confirm()
+                } else {
+                    lockedWindow  = win
+                    hoveredWindow = nil
+                    onWindowSelected?(win)
+                    needsDisplay = true
+                    window?.invalidateCursorRects(for: self)
+                }
+            }
+        case .area:
+            areaMouseDown(at: point, clickCount: event.clickCount)
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard mode == .area else { return }
+        areaMouseDragged(to: convert(event.locationInWindow, from: nil))
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard mode == .area else { return }
+        areaMouseUp(at: convert(event.locationInWindow, from: nil))
+    }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 53:     onCancel?()  // Esc (also caught by presenter's key monitor)
+        case 36, 76: confirm()   // Return / keypad Enter
+        default:     super.keyDown(with: event)
+        }
+    }
+
+    private func confirm() {
+        switch mode {
+        case .fullscreen:            onConfirm?()
+        case .area   where selection != nil: onConfirm?()
+        case .window where lockedWindow != nil: onConfirm?()
+        default: break
+        }
+    }
+
+    // MARK: - Area mode helpers
+
+    private var isDrawing: Bool { if case .drawing = dragMode { return true }; return false }
+
+    private var draftRect: CGRect? {
+        guard let drawStart, let drawCurrent else { return nil }
+        let dx = drawCurrent.x - drawStart.x
+        let dy = drawCurrent.y - drawStart.y
+
+        guard let ratio = aspect.pixelRatio(imageSize: .zero) else {
+            return CGRect(
+                x: min(drawStart.x, drawCurrent.x),
+                y: min(drawStart.y, drawCurrent.y),
+                width: abs(dx), height: abs(dy)
+            )
+        }
+        let cw = abs(dx), ch = abs(dy)
+        let w: CGFloat
+        let h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+        return CGRect(
+            x: dx >= 0 ? drawStart.x : drawStart.x - w,
+            y: dy >= 0 ? drawStart.y : drawStart.y - h,
+            width: w, height: h
+        )
+    }
+
+    private func areaMouseDown(at point: CGPoint, clickCount: Int) {
+        if let sel = selection {
+            if clickCount >= 2, sel.contains(point) { confirm(); return }
+            if let h = handle(at: point, in: sel) { dragMode = .resizing(h); resizeAnchor = sel; return }
+            if sel.contains(point) {
+                dragMode   = .moving
+                moveOffset = CGSize(width: point.x - sel.minX, height: point.y - sel.minY)
+                NSCursor.closedHand.set()
+                return
+            }
+        }
+        dragMode  = .drawing
+        selection = nil
+        onSelectionChanged?(nil)
+        drawStart = point; drawCurrent = point
+        needsDisplay = true
+    }
+
+    private func areaMouseDragged(to point: CGPoint) {
+        switch dragMode {
+        case .drawing:
+            drawCurrent = point
+        case .moving:
+            guard let cur = selection else { break }
+            var moved = cur
+            moved.origin = CGPoint(x: point.x - moveOffset.width, y: point.y - moveOffset.height)
+            selection = clampToBounds(moved)
+            onSelectionChanged?(selection)
+        case .resizing(let h):
+            selection = resizedRect(anchor: resizeAnchor, handle: h, to: point)
+            onSelectionChanged?(selection)
+        case .none: break
+        }
+        needsDisplay = true
+    }
+
+    private func areaMouseUp(at point: CGPoint) {
+        if case .drawing = dragMode {
+            drawCurrent = point
+            if let rect = draftRect, rect.width >= minimumSize, rect.height >= minimumSize {
+                selection = clampToBounds(rect)
+            } else {
+                selection = nil
+            }
+            drawStart = nil; drawCurrent = nil
+            onSelectionChanged?(selection)
+        }
+        dragMode = .none
+        needsDisplay = true
+        window?.invalidateCursorRects(for: self)
+    }
+
+    // MARK: - Area geometry
+
+    private func handlePoint(_ handle: Handle, in rect: CGRect) -> CGPoint {
+        switch handle {
+        case .topLeft:     return CGPoint(x: rect.minX, y: rect.maxY)
+        case .top:         return CGPoint(x: rect.midX, y: rect.maxY)
+        case .topRight:    return CGPoint(x: rect.maxX, y: rect.maxY)
+        case .right:       return CGPoint(x: rect.maxX, y: rect.midY)
+        case .bottomRight: return CGPoint(x: rect.maxX, y: rect.minY)
+        case .bottom:      return CGPoint(x: rect.midX, y: rect.minY)
+        case .bottomLeft:  return CGPoint(x: rect.minX, y: rect.minY)
+        case .left:        return CGPoint(x: rect.minX, y: rect.midY)
+        }
+    }
+
+    private func handleHitRect(_ handle: Handle, in rect: CGRect) -> CGRect {
+        let c = handlePoint(handle, in: rect)
+        let r = handleLength / 2 + handleHitPad
+        return CGRect(x: c.x - r, y: c.y - r, width: r * 2, height: r * 2)
+    }
+
+    private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
+        Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
+    }
+
+    private func resizedRect(anchor: CGRect, handle: Handle, to raw: CGPoint) -> CGRect {
+        let ratio = aspect.pixelRatio(imageSize: .zero)
+        let px = max(bounds.minX, min(raw.x, bounds.maxX))
+        let py = max(bounds.minY, min(raw.y, bounds.maxY))
+        let p  = CGPoint(x: px, y: py)
+
+        switch handle {
+        case .topLeft:
+            if let r = ratio { return aspectLockedCorner(anchorX: anchor.maxX, anchorY: anchor.minY, signX: -1, signY: +1, to: p, ratio: r) }
+        case .topRight:
+            if let r = ratio { return aspectLockedCorner(anchorX: anchor.minX, anchorY: anchor.minY, signX: +1, signY: +1, to: p, ratio: r) }
+        case .bottomLeft:
+            if let r = ratio { return aspectLockedCorner(anchorX: anchor.maxX, anchorY: anchor.maxY, signX: -1, signY: -1, to: p, ratio: r) }
+        case .bottomRight:
+            if let r = ratio { return aspectLockedCorner(anchorX: anchor.minX, anchorY: anchor.maxY, signX: +1, signY: -1, to: p, ratio: r) }
+        default: break
+        }
+
+        var minX = anchor.minX, maxX = anchor.maxX
+        var minY = anchor.minY, maxY = anchor.maxY
+        switch handle {
+        case .left,   .topLeft,     .bottomLeft:  minX = min(px, anchor.maxX - minimumSize)
+        case .right,  .topRight,    .bottomRight: maxX = max(px, anchor.minX + minimumSize)
+        default: break
+        }
+        switch handle {
+        case .bottom, .bottomLeft,  .bottomRight: minY = min(py, anchor.maxY - minimumSize)
+        case .top,    .topLeft,     .topRight:    maxY = max(py, anchor.minY + minimumSize)
+        default: break
+        }
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    private func aspectLockedCorner(
+        anchorX: CGFloat, anchorY: CGFloat,
+        signX: CGFloat, signY: CGFloat,
+        to point: CGPoint, ratio: CGFloat
+    ) -> CGRect {
+        let cw = max((point.x - anchorX) * signX, minimumSize)
+        let ch = max((point.y - anchorY) * signY, minimumSize)
+        var w: CGFloat
+        var h: CGFloat
+        if cw / max(ch, 0.001) > ratio { h = ch; w = h * ratio }
+        else                           { w = cw; h = w / ratio }
+        let maxW = signX > 0 ? bounds.maxX - anchorX : anchorX - bounds.minX
+        let maxH = signY > 0 ? bounds.maxY - anchorY : anchorY - bounds.minY
+        if w > maxW { w = maxW; h = w / ratio }
+        if h > maxH { h = maxH; w = h * ratio }
+        w = max(w, minimumSize); h = max(h, minimumSize)
+        return CGRect(
+            x: signX > 0 ? anchorX : anchorX - w,
+            y: signY > 0 ? anchorY : anchorY - h,
+            width: w, height: h
+        )
+    }
+
+    private func clampToBounds(_ rect: CGRect) -> CGRect {
+        var r = rect
+        r.size.width  = min(r.size.width,  bounds.width)
+        r.size.height = min(r.size.height, bounds.height)
+        r.origin.x    = max(bounds.minX, min(r.origin.x, bounds.maxX - r.width))
+        r.origin.y    = max(bounds.minY, min(r.origin.y, bounds.maxY - r.height))
+        return r
+    }
+
+    // MARK: - Window geometry
+
+    private func windowViewFrame(_ win: SCWindow) -> CGRect {
+        let origin = window?.frame.origin ?? .zero
+        return CGRect(
+            x: win.frame.minX - origin.x,
+            y: win.frame.minY - origin.y,
+            width: win.frame.width,
+            height: win.frame.height
+        )
+    }
+
+    private func windowAtPoint(_ viewPoint: CGPoint) -> SCWindow? {
+        let panelOrigin = window?.frame.origin ?? .zero
+        let screenPoint = CGPoint(
+            x: viewPoint.x + panelOrigin.x,
+            y: viewPoint.y + panelOrigin.y
+        )
+        return windows.first { $0.frame.contains(screenPoint) }
+    }
+
+    // MARK: - Cursor
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        window?.invalidateCursorRects(for: self)
+        if window != nil { NSCursor.annotationPlus.set() }
+    }
+
+    override func resetCursorRects() {
+        switch mode {
+        case .fullscreen, .window:
+            addCursorRect(bounds, cursor: .arrow)
+        case .area:
+            addCursorRect(bounds, cursor: .annotationPlus)
+            guard let sel = selection, !isDrawing else { return }
+            addCursorRect(sel, cursor: .openHand)
+            for h in Handle.allCases {
+                addCursorRect(handleHitRect(h, in: sel), cursor: cursorFor(h))
+            }
+        }
+    }
+
+    private func cursorFor(_ handle: Handle) -> NSCursor {
+        switch handle {
+        case .left, .right:  return .resizeLeftRight
+        case .top, .bottom:  return .resizeUpDown
+        default:             return .crosshair
+        }
+    }
+
+    // MARK: - Size badge
+
+    private func drawSelectionSize(for rect: CGRect) {
+        let pw = Int((rect.width  * pixelScale.width).rounded())
+        let ph = Int((rect.height * pixelScale.height).rounded())
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font:            NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold),
+            .foregroundColor: NSColor.white
+        ]
+        let str      = NSAttributedString(string: "\(pw) x \(ph)", attributes: attrs)
+        let textSize = str.size()
+        let pad      = CGSize(width: 10, height: 6)
+        let bSize    = CGSize(width: textSize.width + pad.width * 2, height: textSize.height + pad.height * 2)
+        let origin   = badgeOrigin(for: rect, size: bSize)
+        let bRect    = CGRect(origin: origin, size: bSize)
+        NSColor.black.withAlphaComponent(0.72).setFill()
+        NSBezierPath(roundedRect: bRect, xRadius: 7, yRadius: 7).fill()
+        str.draw(at: CGPoint(x: bRect.minX + pad.width, y: bRect.minY + pad.height))
+    }
+
+    private func badgeOrigin(for rect: CGRect, size: CGSize) -> CGPoint {
+        let preferred = CGPoint(x: rect.minX, y: rect.minY - size.height - 8)
+        if bounds.contains(CGRect(origin: preferred, size: size)) { return preferred }
+        let fallbackY = min(rect.maxY + 8, bounds.maxY - size.height - 8)
+        return CGPoint(
+            x: min(max(rect.minX, bounds.minX + 8), bounds.maxX - size.width - 8),
+            y: max(fallbackY, bounds.minY + 8)
+        )
+    }
+}

--- a/Screendrop/RecordingSetupPresenter.swift
+++ b/Screendrop/RecordingSetupPresenter.swift
@@ -229,6 +229,7 @@ private final class RecordingSetupOverlayView: NSView {
     private let windows:        [SCWindow]
     private var hoveredWindow:  SCWindow?
     private var lockedWindow:   SCWindow?
+    private var didConfirmWindow = false
 
     // Area mode
     var aspect: CropAspectRatio = .freeform
@@ -269,6 +270,7 @@ private final class RecordingSetupOverlayView: NSView {
         selection     = nil
         hoveredWindow = nil
         lockedWindow  = nil
+        didConfirmWindow = false
         drawStart     = nil
         drawCurrent   = nil
         dragMode      = .none
@@ -424,12 +426,22 @@ private final class RecordingSetupOverlayView: NSView {
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func mouseMoved(with event: NSEvent) {
-        guard mode == .window, lockedWindow == nil else { return }
+        guard mode == .window, !didConfirmWindow else { return }
+
+        // Hover is already proof the cursor is over the overlay. Re-key here
+        // instead of only in mouseEntered because moving from the child toolbar
+        // back to the overlay can continue delivering mouseMoved without a
+        // reliable enter transition.
+        window?.makeKey()
+
         let point    = convert(event.locationInWindow, from: nil)
         let newHover = windowAtPoint(point)
         if newHover?.windowID != hoveredWindow?.windowID {
             hoveredWindow = newHover
+            lockedWindow = newHover
+            onWindowSelected?(newHover)
             needsDisplay  = true
+            window?.invalidateCursorRects(for: self)
         }
     }
 
@@ -443,12 +455,7 @@ private final class RecordingSetupOverlayView: NSView {
             // (screencapture -w) and with Full Screen mode above: clicking a
             // window selects and starts recording it immediately. Fall back to
             // the hovered window so a tiny cursor jitter on click can't miss.
-            if let win = windowAtPoint(point) ?? hoveredWindow {
-                lockedWindow  = win
-                hoveredWindow = nil
-                onWindowSelected?(win)
-                confirm()
-            }
+            confirmWindow(windowAtPoint(point) ?? hoveredWindow ?? lockedWindow)
         case .area:
             areaMouseDown(at: point, clickCount: event.clickCount)
         }
@@ -460,8 +467,18 @@ private final class RecordingSetupOverlayView: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
-        guard mode == .area else { return }
-        areaMouseUp(at: convert(event.locationInWindow, from: nil))
+        let point = convert(event.locationInWindow, from: nil)
+
+        switch mode {
+        case .window:
+            // Fallback for first-mouse/key-window edge cases where AppKit
+            // delivers hover but swallows mouseDown.
+            confirmWindow(windowAtPoint(point) ?? hoveredWindow ?? lockedWindow)
+        case .area:
+            areaMouseUp(at: point)
+        case .fullscreen:
+            break
+        }
     }
 
     override func keyDown(with event: NSEvent) {
@@ -479,6 +496,16 @@ private final class RecordingSetupOverlayView: NSView {
         case .window where lockedWindow != nil: onConfirm?()
         default: break
         }
+    }
+
+    private func confirmWindow(_ window: SCWindow?) {
+        guard mode == .window, !didConfirmWindow, let window else { return }
+
+        didConfirmWindow = true
+        lockedWindow = window
+        hoveredWindow = nil
+        onWindowSelected?(window)
+        confirm()
     }
 
     // MARK: - Area mode helpers
@@ -717,6 +744,9 @@ private final class RecordingSetupOverlayView: NSView {
         switch mode {
         case .fullscreen, .window:
             addCursorRect(bounds, cursor: .arrow)
+            if mode == .window, let target = hoveredWindow ?? lockedWindow {
+                addCursorRect(windowViewFrame(target), cursor: .pointingHand)
+            }
         case .area:
             addCursorRect(bounds, cursor: .annotationPlus)
             guard let sel = selection, !isDrawing else { return }

--- a/Screendrop/RecordingSetupPresenter.swift
+++ b/Screendrop/RecordingSetupPresenter.swift
@@ -346,7 +346,7 @@ private final class RecordingSetupOverlayView: NSView {
     private func drawWindowMode() {
         let target = lockedWindow ?? hoveredWindow
         guard let target else {
-            drawHint("Hover over a window to select it")
+            drawHint("Move over a window, then click to record it")
             return
         }
         let vf = windowViewFrame(target)
@@ -357,9 +357,7 @@ private final class RecordingSetupOverlayView: NSView {
         path.lineWidth = 2
         path.stroke()
         drawWindowLabel(for: target, near: vf)
-        if lockedWindow != nil {
-            drawHint("Press Return or click Start to record")
-        }
+        drawHint("Click to record this window")
     }
 
     /// Corners only when an aspect preset is active — edge handles would
@@ -440,16 +438,15 @@ private final class RecordingSetupOverlayView: NSView {
         case .fullscreen:
             confirm()
         case .window:
-            if let win = windowAtPoint(point) {
-                if event.clickCount >= 2, win.windowID == lockedWindow?.windowID {
-                    confirm()
-                } else {
-                    lockedWindow  = win
-                    hoveredWindow = nil
-                    onWindowSelected?(win)
-                    needsDisplay = true
-                    window?.invalidateCursorRects(for: self)
-                }
+            // Consistent with the native screenshot window picker
+            // (screencapture -w) and with Full Screen mode above: clicking a
+            // window selects and starts recording it immediately. Fall back to
+            // the hovered window so a tiny cursor jitter on click can't miss.
+            if let win = windowAtPoint(point) ?? hoveredWindow {
+                lockedWindow  = win
+                hoveredWindow = nil
+                onWindowSelected?(win)
+                confirm()
             }
         case .area:
             areaMouseDown(at: point, clickCount: event.clickCount)

--- a/Screendrop/RecordingSetupPresenter.swift
+++ b/Screendrop/RecordingSetupPresenter.swift
@@ -362,8 +362,16 @@ private final class RecordingSetupOverlayView: NSView {
         }
     }
 
+    /// Corners only when an aspect preset is active — edge handles would
+    /// silently break the ratio lock.
+    private var activeHandles: [Handle] {
+        aspect.locksAspect
+            ? [.topLeft, .topRight, .bottomLeft, .bottomRight]
+            : Handle.allCases
+    }
+
     private func drawHandles(for rect: CGRect) {
-        for handle in Handle.allCases {
+        for handle in activeHandles {
             let center = handlePoint(handle, in: rect)
             let sq = CGRect(
                 x: center.x - handleLength / 2, y: center.y - handleLength / 2,
@@ -577,7 +585,7 @@ private final class RecordingSetupOverlayView: NSView {
     }
 
     private func handle(at point: CGPoint, in rect: CGRect) -> Handle? {
-        Handle.allCases.first { handleHitRect($0, in: rect).contains(point) }
+        activeHandles.first { handleHitRect($0, in: rect).contains(point) }
     }
 
     private func resizedRect(anchor: CGRect, handle: Handle, to raw: CGPoint) -> CGRect {
@@ -646,24 +654,35 @@ private final class RecordingSetupOverlayView: NSView {
     }
 
     // MARK: - Window geometry
+    //
+    // SCWindow.frame uses Core Graphics screen coordinates:
+    //   origin = top-left of the primary display, y increases downward.
+    // The overlay NSView uses AppKit coordinates:
+    //   origin = bottom-left of its display, y increases upward.
+    // These must be converted before comparing or drawing.
 
     private func windowViewFrame(_ win: SCWindow) -> CGRect {
-        let origin = window?.frame.origin ?? .zero
+        // CG → AppKit: flip y using the primary display's height as the reference.
+        let mainH       = NSScreen.screens.first?.frame.height ?? bounds.height
+        let appKitX     = win.frame.minX
+        let appKitY     = mainH - win.frame.minY - win.frame.height
+        let panelOrigin = window?.frame.origin ?? .zero
         return CGRect(
-            x: win.frame.minX - origin.x,
-            y: win.frame.minY - origin.y,
-            width: win.frame.width,
+            x:      appKitX - panelOrigin.x,
+            y:      appKitY - panelOrigin.y,
+            width:  win.frame.width,
             height: win.frame.height
         )
     }
 
     private func windowAtPoint(_ viewPoint: CGPoint) -> SCWindow? {
+        // Convert the view-local point → CG screen coordinates for comparison
+        // with SCWindow.frame.
+        let mainH       = NSScreen.screens.first?.frame.height ?? bounds.height
         let panelOrigin = window?.frame.origin ?? .zero
-        let screenPoint = CGPoint(
-            x: viewPoint.x + panelOrigin.x,
-            y: viewPoint.y + panelOrigin.y
-        )
-        return windows.first { $0.frame.contains(screenPoint) }
+        let cgX = viewPoint.x + panelOrigin.x
+        let cgY = mainH - (viewPoint.y + panelOrigin.y)
+        return windows.first { $0.frame.contains(CGPoint(x: cgX, y: cgY)) }
     }
 
     // MARK: - Cursor
@@ -682,7 +701,7 @@ private final class RecordingSetupOverlayView: NSView {
             addCursorRect(bounds, cursor: .annotationPlus)
             guard let sel = selection, !isDrawing else { return }
             addCursorRect(sel, cursor: .openHand)
-            for h in Handle.allCases {
+            for h in activeHandles {
                 addCursorRect(handleHitRect(h, in: sel), cursor: cursorFor(h))
             }
         }

--- a/Screendrop/RecordingSetupPresenter.swift
+++ b/Screendrop/RecordingSetupPresenter.swift
@@ -249,6 +249,7 @@ private final class RecordingSetupOverlayView: NSView {
     private var dragMode:     DragMode = .none
     private var moveOffset:   CGSize   = .zero
     private var resizeAnchor: CGRect   = .zero
+    private var trackingArea: NSTrackingArea?
 
     override var acceptsFirstResponder: Bool { true }
 
@@ -680,6 +681,28 @@ private final class RecordingSetupOverlayView: NSView {
         let cgX = viewPoint.x + panelOrigin.x
         let cgY = mainH - (viewPoint.y + panelOrigin.y)
         return windows.first { $0.frame.contains(CGPoint(x: cgX, y: cgY)) }
+    }
+
+    // MARK: - Tracking / key
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea { removeTrackingArea(trackingArea) }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.activeAlways, .inVisibleRect, .mouseMoved, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        // Re-key the overlay whenever the cursor returns to it (e.g. after
+        // clicking the toolbar's mode picker), so the next click is a normal
+        // mouseDown instead of a swallowed first-mouse activation click.
+        window?.makeKey()
     }
 
     // MARK: - Cursor

--- a/Screendrop/RecordingSetupPresenter.swift
+++ b/Screendrop/RecordingSetupPresenter.swift
@@ -2,8 +2,8 @@
 //  RecordingSetupPresenter.swift
 //  Screendrop
 //
-//  Unified entry point for the recording setup HUD (Full Screen / Area /
-//  Window).  Shows a full-screen selection overlay and a floating toolbar,
+//  Unified entry point for the recording setup HUD (Full Screen / Area).
+//  Shows a full-screen selection overlay and a floating toolbar,
 //  then hands a resolved ScreenRecordingSource to ScreenRecordingManager.
 //
 //  Area mode geometry (drag, 8 handles, aspect lock) mirrors the logic in
@@ -31,7 +31,7 @@ final class RecordingSetupPresenter {
 
     private init() {}
 
-    /// Resolve the active display, load window sources, and present the HUD.
+    /// Resolve the active display and present the HUD.
     func begin() {
         // Don't interrupt an in-flight recording.
         guard ScreenRecordingManager.shared.state == .idle else { return }
@@ -40,12 +40,11 @@ final class RecordingSetupPresenter {
         Task {
             do {
                 let content  = try await ScreenRecordingCapture.availableContent()
-                let windows  = RecordingSourceCatalog.pickableWindows(from: content)
                 guard let display = content.displays.first(where: { $0.displayID == displayID })
                                  ?? content.displays.first else { return }
                 guard let screen = ActiveDisplayResolver.screen(for: display.displayID)
                                 ?? NSScreen.main else { return }
-                show(display: display, windows: windows, screen: screen)
+                show(display: display, screen: screen)
             } catch {
                 // Screen recording permission denied or SCK unavailable — fail silently.
             }
@@ -56,7 +55,7 @@ final class RecordingSetupPresenter {
 
     // MARK: Private — lifecycle
 
-    private func show(display: SCDisplay, windows: [SCWindow], screen: NSScreen) {
+    private func show(display: SCDisplay, screen: NSScreen) {
         dismiss()   // tear down any previous HUD
 
         self.display = display
@@ -87,13 +86,11 @@ final class RecordingSetupPresenter {
 
         let ov = RecordingSetupOverlayView(
             frame:      CGRect(origin: .zero, size: screen.frame.size),
-            pixelScale: pixelScale,
-            windows:    windows
+            pixelScale: pixelScale
         )
         ov.onConfirm          = { [weak self] in self?.confirm() }
         ov.onCancel           = { [weak self] in self?.dismiss() }
         ov.onSelectionChanged = { [weak setupModel] rect in setupModel?.selection = rect }
-        ov.onWindowSelected   = { [weak setupModel] win  in setupModel?.selectedWindow = win }
 
         panel.contentView = ov
         panel.makeFirstResponder(ov)
@@ -141,9 +138,6 @@ final class RecordingSetupPresenter {
         case .area:
             guard let rect = model.selection else { return nil }
             return ScreenRecordingSource(kind: .area(display: display, rect: rect))
-        case .window:
-            guard let win = model.selectedWindow else { return nil }
-            return ScreenRecordingSource(kind: .window(win))
         }
     }
 
@@ -208,7 +202,7 @@ private final class RecordingSetupKeyPanel: NSPanel {
 
 // MARK: - Overlay view
 
-/// Full-screen overlay that handles all three recording modes.
+/// Full-screen overlay that handles the setup HUD's recording modes.
 ///
 /// Area mode geometry (drag, 8 handles, aspect-lock) is intentionally
 /// duplicated from `RecordingAreaSelectionView` and will be consolidated
@@ -219,16 +213,10 @@ private final class RecordingSetupOverlayView: NSView {
     var onConfirm:          (() -> Void)?
     var onCancel:           (() -> Void)?
     var onSelectionChanged: ((CGRect?) -> Void)?
-    var onWindowSelected:   ((SCWindow?) -> Void)?
 
     // MARK: State
 
     private(set) var mode: RecordingSetupMode = .area
-
-    // Window mode
-    private let windows:        [SCWindow]
-    private var hoveredWindow:  SCWindow?
-    private var lockedWindow:   SCWindow?
 
     // Area mode
     var aspect: CropAspectRatio = .freeform
@@ -253,9 +241,8 @@ private final class RecordingSetupOverlayView: NSView {
 
     override var acceptsFirstResponder: Bool { true }
 
-    init(frame: NSRect, pixelScale: CGSize, windows: [SCWindow]) {
+    init(frame: NSRect, pixelScale: CGSize) {
         self.pixelScale = pixelScale
-        self.windows    = windows
         super.init(frame: frame)
         wantsLayer = true
     }
@@ -267,13 +254,10 @@ private final class RecordingSetupOverlayView: NSView {
     func applyMode(_ newMode: RecordingSetupMode) {
         mode          = newMode
         selection     = nil
-        hoveredWindow = nil
-        lockedWindow  = nil
         drawStart     = nil
         drawCurrent   = nil
         dragMode      = .none
         onSelectionChanged?(nil)
-        onWindowSelected?(nil)
         needsDisplay = true
         window?.invalidateCursorRects(for: self)
     }
@@ -309,7 +293,6 @@ private final class RecordingSetupOverlayView: NSView {
         switch mode {
         case .fullscreen: drawFullscreenMode()
         case .area:       drawAreaMode()
-        case .window:     drawWindowMode()
         }
     }
 
@@ -342,38 +325,6 @@ private final class RecordingSetupOverlayView: NSView {
         if !isDrawing, selection == nil {
             drawHint("Drag to select an area")
         }
-    }
-
-    private func drawWindowMode() {
-        guard hoveredWindow != nil || lockedWindow != nil else {
-            drawHint("Move over a window, then click to record it")
-            return
-        }
-
-        if let lockedWindow {
-            drawWindowOutline(for: lockedWindow, selected: true)
-        }
-
-        if let hoveredWindow, hoveredWindow.windowID != lockedWindow?.windowID {
-            drawWindowOutline(for: hoveredWindow, selected: false)
-        }
-
-        if lockedWindow != nil {
-            drawHint("Click Start or press Return to record selected window")
-        } else {
-            drawHint("Click to select this window")
-        }
-    }
-
-    private func drawWindowOutline(for window: SCWindow, selected: Bool) {
-        let vf = windowViewFrame(window)
-        NSColor.clear.setFill()
-        vf.fill(using: .clear)
-        (selected ? NSColor.controlAccentColor : NSColor.white).withAlphaComponent(0.96).setStroke()
-        let path = NSBezierPath(roundedRect: vf, xRadius: 4, yRadius: 4)
-        path.lineWidth = selected ? 3 : 2
-        path.stroke()
-        drawWindowLabel(for: window, near: vf, selected: selected)
     }
 
     /// Corners only when an aspect preset is active — edge handles would
@@ -417,66 +368,15 @@ private final class RecordingSetupOverlayView: NSView {
         str.draw(at: CGPoint(x: bRect.minX + pad.width, y: bRect.minY + pad.height))
     }
 
-    private func drawWindowLabel(for win: SCWindow, near rect: CGRect, selected: Bool = false) {
-        let text = selected
-            ? "Selected · \(RecordingSourceCatalog.windowTitle(win))"
-            : RecordingSourceCatalog.windowTitle(win)
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font:            NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold),
-            .foregroundColor: NSColor.white
-        ]
-        let str      = NSAttributedString(string: text, attributes: attrs)
-        let textSize = str.size()
-        let pad      = CGSize(width: 10, height: 6)
-        let bSize    = CGSize(width: textSize.width + pad.width * 2, height: textSize.height + pad.height * 2)
-        let origin   = badgeOrigin(for: rect, size: bSize)
-        let bRect    = CGRect(origin: origin, size: bSize)
-        NSColor.black.withAlphaComponent(0.72).setFill()
-        NSBezierPath(roundedRect: bRect, xRadius: 7, yRadius: 7).fill()
-        str.draw(at: CGPoint(x: bRect.minX + pad.width, y: bRect.minY + pad.height))
-    }
-
     // MARK: - Mouse events
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-
-    override func mouseMoved(with event: NSEvent) {
-        guard mode == .window else { return }
-
-        // Hover is already proof the cursor is over the overlay. Re-key here
-        // instead of only in mouseEntered because moving from the child toolbar
-        // back to the overlay can continue delivering mouseMoved without a
-        // reliable enter transition.
-        window?.makeKey()
-
-        let point    = convert(event.locationInWindow, from: nil)
-        let newHover = windowAtPoint(point)
-        if newHover?.windowID != hoveredWindow?.windowID {
-            hoveredWindow = newHover
-            if newHover == nil {
-                NSCursor.arrow.set()
-            } else {
-                NSCursor.pointingHand.set()
-            }
-            needsDisplay  = true
-            window?.invalidateCursorRects(for: self)
-        }
-    }
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
         switch mode {
         case .fullscreen:
             confirm()
-        case .window:
-            if let win = windowAtPoint(point) ?? hoveredWindow {
-                selectWindow(win)
-                if event.clickCount >= 2 {
-                    confirm()
-                }
-            } else {
-                selectWindow(nil)
-            }
         case .area:
             areaMouseDown(at: point, clickCount: event.clickCount)
         }
@@ -491,13 +391,6 @@ private final class RecordingSetupOverlayView: NSView {
         let point = convert(event.locationInWindow, from: nil)
 
         switch mode {
-        case .window:
-            // Fallback for first-mouse/key-window edge cases where AppKit
-            // delivers hover but swallows mouseDown. Do not record here;
-            // just lock selection so Start becomes enabled.
-            if lockedWindow == nil {
-                selectWindow(windowAtPoint(point) ?? hoveredWindow)
-            }
         case .area:
             areaMouseUp(at: point)
         case .fullscreen:
@@ -517,16 +410,8 @@ private final class RecordingSetupOverlayView: NSView {
         switch mode {
         case .fullscreen:            onConfirm?()
         case .area   where selection != nil: onConfirm?()
-        case .window where lockedWindow != nil: onConfirm?()
         default: break
         }
-    }
-
-    private func selectWindow(_ window: SCWindow?) {
-        lockedWindow = window
-        onWindowSelected?(window)
-        needsDisplay = true
-        self.window?.invalidateCursorRects(for: self)
     }
 
     // MARK: - Area mode helpers
@@ -699,46 +584,6 @@ private final class RecordingSetupOverlayView: NSView {
         return r
     }
 
-    // MARK: - Window geometry
-    //
-    // SCWindow.frame uses Core Graphics screen coordinates:
-    //   origin = top-left of the primary display, y increases downward.
-    // The overlay NSView uses AppKit coordinates:
-    //   origin = bottom-left of its display, y increases upward.
-    // These must be converted before comparing or drawing.
-
-    private func windowViewFrame(_ win: SCWindow) -> CGRect {
-        // CG → AppKit: flip y using the primary display's height as the reference.
-        let mainH       = NSScreen.screens.first?.frame.height ?? bounds.height
-        let appKitX     = win.frame.minX
-        let appKitY     = mainH - win.frame.minY - win.frame.height
-        let panelOrigin = window?.frame.origin ?? .zero
-        return CGRect(
-            x:      appKitX - panelOrigin.x,
-            y:      appKitY - panelOrigin.y,
-            width:  win.frame.width,
-            height: win.frame.height
-        )
-    }
-
-    private func windowAtPoint(_ viewPoint: CGPoint) -> SCWindow? {
-        // Use the same local AppKit frame for hit-testing that we use for
-        // drawing the highlight. This keeps the visible target and clickable
-        // target identical, and filters windows not meaningfully visible on
-        // this overlay/display.
-        windows.first { window in
-            let frame = windowViewFrame(window)
-            guard isVisibleWindowFrame(frame) else { return false }
-            return frame.contains(viewPoint)
-        }
-    }
-
-    private func isVisibleWindowFrame(_ frame: CGRect) -> Bool {
-        guard frame.intersects(bounds) else { return false }
-        let visible = frame.intersection(bounds)
-        return visible.width >= 32 && visible.height >= 32
-    }
-
     // MARK: - Tracking / key
 
     override func updateTrackingAreas() {
@@ -771,12 +616,8 @@ private final class RecordingSetupOverlayView: NSView {
 
     override func resetCursorRects() {
         switch mode {
-        case .fullscreen, .window:
+        case .fullscreen:
             addCursorRect(bounds, cursor: .arrow)
-            if mode == .window, let target = hoveredWindow ?? lockedWindow,
-               isVisibleWindowFrame(windowViewFrame(target)) {
-                addCursorRect(windowViewFrame(target), cursor: .pointingHand)
-            }
         case .area:
             addCursorRect(bounds, cursor: .annotationPlus)
             guard let sel = selection, !isDrawing else { return }

--- a/Screendrop/RecordingSetupToolbarView.swift
+++ b/Screendrop/RecordingSetupToolbarView.swift
@@ -2,9 +2,10 @@
 //  RecordingSetupToolbarView.swift
 //  Screendrop
 //
-//  Floating toolbar shown during area-recording setup. Displays aspect-ratio
-//  preset chips, a live pixel-size readout, and Start / Cancel actions.
-//  Hosted in a borderless NSPanel by RecordingAreaSelectionPresenter.
+//  Floating toolbar shown during recording setup.  Hosts a mode picker
+//  (Full Screen / Area / Window), aspect-ratio chips (Area only), a live
+//  pixel-size readout, and Start / Cancel actions.
+//  Hosted in a borderless NSPanel by RecordingSetupPresenter.
 //
 
 import SwiftUI
@@ -13,13 +14,14 @@ struct RecordingSetupToolbarView: View {
 
     @Bindable var model: RecordingSetupModel
 
-    var onStart: () -> Void
-    var onCancel: () -> Void
-    /// Called when the user picks an aspect chip so the AppKit overlay can
-    /// apply the constraint to the current selection synchronously.
+    var onStart:        () -> Void
+    var onCancel:       () -> Void
+    /// Aspect chip tapped — lets the AppKit overlay apply the constraint synchronously.
     var onAspectChange: (CropAspectRatio) -> Void
+    /// Mode chip tapped — lets the AppKit overlay reset state for the new mode.
+    var onModeChange:   (RecordingSetupMode) -> Void
 
-    private let presets: [(aspect: CropAspectRatio, label: String)] = [
+    private let aspects: [(aspect: CropAspectRatio, label: String)] = [
         (.freeform,    "Freeform"),
         (.sixteenNine, "16:9"),
         (.nineSixteen, "9:16"),
@@ -30,34 +32,49 @@ struct RecordingSetupToolbarView: View {
     var body: some View {
         HStack(spacing: 10) {
 
-            // Aspect-ratio chips
-            HStack(spacing: 4) {
-                ForEach(presets, id: \.aspect.id) { item in
-                    Button(item.label) {
-                        model.aspect = item.aspect
-                        onAspectChange(item.aspect)
+            // ── Mode picker ───────────────────────────────────────────────
+            Picker("", selection: $model.mode) {
+                ForEach(RecordingSetupMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .fixedSize()
+            .onChange(of: model.mode) { _, newMode in
+                onModeChange(newMode)
+            }
+
+            // ── Aspect chips (Area only) ───────────────────────────────────
+            if model.mode == .area {
+                toolbarDivider
+
+                HStack(spacing: 4) {
+                    ForEach(aspects, id: \.aspect.id) { item in
+                        Button(item.label) {
+                            model.aspect = item.aspect
+                            onAspectChange(item.aspect)
+                        }
+                        .buttonStyle(AspectChipStyle(isActive: model.aspect == item.aspect))
                     }
-                    .buttonStyle(AspectChipStyle(isActive: model.aspect == item.aspect))
                 }
+
+                toolbarDivider
+
+                // Live pixel size
+                Group {
+                    if let size = model.pixelSize {
+                        Text("\(Int(size.width)) × \(Int(size.height))")
+                    } else {
+                        Text("W × H").foregroundStyle(.tertiary)
+                    }
+                }
+                .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                .frame(minWidth: 76, alignment: .leading)
             }
 
             toolbarDivider
 
-            // Live pixel size
-            Group {
-                if let size = model.pixelSize {
-                    Text("\(Int(size.width)) × \(Int(size.height))")
-                } else {
-                    Text("W × H")
-                        .foregroundStyle(.tertiary)
-                }
-            }
-            .font(.system(size: 12, weight: .semibold).monospacedDigit())
-            .frame(minWidth: 76, alignment: .leading)
-
-            toolbarDivider
-
-            // Cancel / Start
+            // ── Cancel / Start ─────────────────────────────────────────────
             Button("Cancel", action: onCancel)
                 .foregroundStyle(.secondary)
 
@@ -66,7 +83,7 @@ struct RecordingSetupToolbarView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.red)
-            .disabled(model.selection == nil)
+            .disabled(!model.canStart)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -80,7 +97,7 @@ struct RecordingSetupToolbarView: View {
                 .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
         .shadow(color: .black.opacity(0.22), radius: 10, y: 4)
-        .padding(10)   // give the shadow room to breathe
+        .padding(10)
     }
 
     private var toolbarDivider: some View {

--- a/Screendrop/RecordingSetupToolbarView.swift
+++ b/Screendrop/RecordingSetupToolbarView.swift
@@ -1,0 +1,112 @@
+//
+//  RecordingSetupToolbarView.swift
+//  Screendrop
+//
+//  Floating toolbar shown during area-recording setup. Displays aspect-ratio
+//  preset chips, a live pixel-size readout, and Start / Cancel actions.
+//  Hosted in a borderless NSPanel by RecordingAreaSelectionPresenter.
+//
+
+import SwiftUI
+
+struct RecordingSetupToolbarView: View {
+
+    @Bindable var model: RecordingSetupModel
+
+    var onStart: () -> Void
+    var onCancel: () -> Void
+    /// Called when the user picks an aspect chip so the AppKit overlay can
+    /// apply the constraint to the current selection synchronously.
+    var onAspectChange: (CropAspectRatio) -> Void
+
+    private let presets: [(aspect: CropAspectRatio, label: String)] = [
+        (.freeform,    "Freeform"),
+        (.sixteenNine, "16:9"),
+        (.nineSixteen, "9:16"),
+        (.square,      "1:1"),
+        (.fourThree,   "4:3"),
+    ]
+
+    var body: some View {
+        HStack(spacing: 10) {
+
+            // Aspect-ratio chips
+            HStack(spacing: 4) {
+                ForEach(presets, id: \.aspect.id) { item in
+                    Button(item.label) {
+                        model.aspect = item.aspect
+                        onAspectChange(item.aspect)
+                    }
+                    .buttonStyle(AspectChipStyle(isActive: model.aspect == item.aspect))
+                }
+            }
+
+            toolbarDivider
+
+            // Live pixel size
+            Group {
+                if let size = model.pixelSize {
+                    Text("\(Int(size.width)) × \(Int(size.height))")
+                } else {
+                    Text("W × H")
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .font(.system(size: 12, weight: .semibold).monospacedDigit())
+            .frame(minWidth: 76, alignment: .leading)
+
+            toolbarDivider
+
+            // Cancel / Start
+            Button("Cancel", action: onCancel)
+                .foregroundStyle(.secondary)
+
+            Button(action: onStart) {
+                Label("Start", systemImage: "record.circle.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+            .disabled(model.selection == nil)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .fixedSize()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.regularMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.22), radius: 10, y: 4)
+        .padding(10)   // give the shadow room to breathe
+    }
+
+    private var toolbarDivider: some View {
+        Rectangle()
+            .fill(Color(nsColor: .separatorColor))
+            .frame(width: 1, height: 20)
+    }
+}
+
+// MARK: - Chip button style
+
+private struct AspectChipStyle: ButtonStyle {
+    let isActive: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 12, weight: .medium))
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(
+                isActive
+                    ? Color.accentColor
+                    : Color(nsColor: .controlColor).opacity(0.7)
+            )
+            .foregroundStyle(isActive ? Color.white : Color.primary)
+            .clipShape(Capsule())
+            .opacity(configuration.isPressed ? 0.75 : 1)
+    }
+}

--- a/Screendrop/RecordingSetupToolbarView.swift
+++ b/Screendrop/RecordingSetupToolbarView.swift
@@ -2,9 +2,11 @@
 //  RecordingSetupToolbarView.swift
 //  Screendrop
 //
-//  Floating toolbar shown during area-recording setup. Displays aspect-ratio
-//  preset chips, a live pixel-size readout, and Start / Cancel actions.
-//  Hosted in a borderless NSPanel by RecordingAreaSelectionPresenter.
+//  Floating toolbar shown during area-recording setup.  Uses a dark HUD
+//  appearance so it reads clearly against the dimmed screen overlay, avoiding
+//  the flat rendering that .regularMaterial produces in non-activating panels.
+//  Start is a vivid red pill (obvious primary action); Cancel is a muted text
+//  label that stays accessible without competing with Start.
 //
 
 import SwiftUI
@@ -13,13 +15,13 @@ struct RecordingSetupToolbarView: View {
 
     @Bindable var model: RecordingSetupModel
 
-    var onStart: () -> Void
-    var onCancel: () -> Void
-    /// Called when the user picks an aspect chip so the AppKit overlay can
-    /// apply the constraint to the current selection synchronously.
+    var onStart:        () -> Void
+    var onCancel:       () -> Void
     var onAspectChange: (CropAspectRatio) -> Void
+    /// Called when a future mode control changes mode (wired in PR 3).
+    var onModeChange:   (Any) -> Void
 
-    private let presets: [(aspect: CropAspectRatio, label: String)] = [
+    private let aspects: [(aspect: CropAspectRatio, label: String)] = [
         (.freeform,    "Freeform"),
         (.sixteenNine, "16:9"),
         (.nineSixteen, "9:16"),
@@ -30,83 +32,107 @@ struct RecordingSetupToolbarView: View {
     var body: some View {
         HStack(spacing: 10) {
 
-            // Aspect-ratio chips
+            // ── Aspect-ratio chips ─────────────────────────────────────────
             HStack(spacing: 4) {
-                ForEach(presets, id: \.aspect.id) { item in
+                ForEach(aspects, id: \.aspect.id) { item in
                     Button(item.label) {
                         model.aspect = item.aspect
                         onAspectChange(item.aspect)
                     }
-                    .buttonStyle(AspectChipStyle(isActive: model.aspect == item.aspect))
+                    .buttonStyle(HUDAspectChipStyle(isActive: model.aspect == item.aspect))
                 }
             }
 
-            toolbarDivider
+            separator
 
-            // Live pixel size
+            // ── Live pixel size ────────────────────────────────────────────
             Group {
                 if let size = model.pixelSize {
                     Text("\(Int(size.width)) × \(Int(size.height))")
+                        .foregroundStyle(.white)
                 } else {
                     Text("W × H")
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.white.opacity(0.4))
                 }
             }
             .font(.system(size: 12, weight: .semibold).monospacedDigit())
             .frame(minWidth: 76, alignment: .leading)
 
-            toolbarDivider
+            separator
 
-            // Cancel / Start
+            // ── Cancel ─────────────────────────────────────────────────────
             Button("Cancel", action: onCancel)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.white.opacity(0.7))
 
+            // ── Start ──────────────────────────────────────────────────────
             Button(action: onStart) {
                 Label("Start", systemImage: "record.circle.fill")
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.red)
+            .buttonStyle(HUDStartButtonStyle())
             .disabled(model.selection == nil)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .fixedSize()
+        // Dark HUD: clear and readable on any dimmed overlay; avoids the
+        // flat appearance of .regularMaterial in non-activating panels.
         .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(.regularMaterial)
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color.black.opacity(0.78))
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.22), radius: 10, y: 4)
-        .padding(10)   // give the shadow room to breathe
+        .shadow(color: .black.opacity(0.5), radius: 16, y: 5)
+        .padding(10)
+        // Force dark scheme so the system controls inside render correctly
+        // on the dark background.
+        .environment(\.colorScheme, .dark)
     }
 
-    private var toolbarDivider: some View {
+    private var separator: some View {
         Rectangle()
-            .fill(Color(nsColor: .separatorColor))
+            .fill(Color.white.opacity(0.18))
             .frame(width: 1, height: 20)
     }
 }
 
-// MARK: - Chip button style
+// MARK: - Button styles
 
-private struct AspectChipStyle: ButtonStyle {
+/// Aspect-ratio chip on the dark HUD toolbar.
+/// Active state: white fill + black text.  Inactive: subtle ghost pill.
+private struct HUDAspectChipStyle: ButtonStyle {
     let isActive: Bool
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(isActive ? Color.black : Color.white)
             .padding(.horizontal, 9)
             .padding(.vertical, 5)
             .background(
                 isActive
-                    ? Color.accentColor
-                    : Color(nsColor: .controlColor).opacity(0.7)
+                    ? Color.white
+                    : Color.white.opacity(0.12)
             )
-            .foregroundStyle(isActive ? Color.white : Color.primary)
             .clipShape(Capsule())
+            .opacity(configuration.isPressed ? 0.7 : 1)
+    }
+}
+
+/// Primary Start button.  Red when enabled, invisible-ish when disabled;
+/// animates between states so the moment a selection is drawn is felt.
+private struct HUDStartButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .background(
+                Capsule()
+                    .fill(isEnabled ? Color.red : Color.white.opacity(0.15))
+            )
             .opacity(configuration.isPressed ? 0.75 : 1)
+            .animation(.easeInOut(duration: 0.18), value: isEnabled)
     }
 }

--- a/Screendrop/RecordingSourceCatalog.swift
+++ b/Screendrop/RecordingSourceCatalog.swift
@@ -52,24 +52,9 @@ final class RecordingSourceCatalog {
     }
 
     static func filteredWindows(from content: SCShareableContent) -> [SCWindow] {
-        let ownBundleID = Bundle.main.bundleIdentifier
         var seenKeys: Set<String> = []
 
-        return content.windows
-            .filter { window in
-                guard window.isOnScreen,
-                      window.windowLayer == 0,
-                      window.frame.width >= 160,
-                      window.frame.height >= 100,
-                      let app = window.owningApplication,
-                      app.bundleIdentifier != ownBundleID,
-                      !isBlockedApplication(app),
-                      !isBlockedTitle(window.title, app: app) else {
-                    return false
-                }
-
-                return true
-            }
+        return pickableWindows(from: content)
             .filter { window in
                 let key = dedupeKey(for: window)
                 guard !seenKeys.contains(key) else { return false }
@@ -80,6 +65,27 @@ final class RecordingSourceCatalog {
             .sorted { lhs, rhs in
                 windowTitle(lhs).localizedCaseInsensitiveCompare(windowTitle(rhs)) == .orderedAscending
             }
+    }
+
+    /// Windows suitable for spatial hit-testing in the recording setup overlay.
+    /// Preserves ScreenCaptureKit's source order instead of sorting by title.
+    static func pickableWindows(from content: SCShareableContent) -> [SCWindow] {
+        let ownBundleID = Bundle.main.bundleIdentifier
+
+        return content.windows.filter { window in
+            guard window.isOnScreen,
+                  window.windowLayer == 0,
+                  window.frame.width >= 160,
+                  window.frame.height >= 100,
+                  let app = window.owningApplication,
+                  app.bundleIdentifier != ownBundleID,
+                  !isBlockedApplication(app),
+                  !isBlockedTitle(window.title, app: app) else {
+                return false
+            }
+
+            return true
+        }
     }
 
     private static func isBlockedApplication(_ app: SCRunningApplication) -> Bool {

--- a/Screendrop/RecordingSourceCatalog.swift
+++ b/Screendrop/RecordingSourceCatalog.swift
@@ -52,9 +52,24 @@ final class RecordingSourceCatalog {
     }
 
     static func filteredWindows(from content: SCShareableContent) -> [SCWindow] {
+        let ownBundleID = Bundle.main.bundleIdentifier
         var seenKeys: Set<String> = []
 
-        return pickableWindows(from: content)
+        return content.windows
+            .filter { window in
+                guard window.isOnScreen,
+                      window.windowLayer == 0,
+                      window.frame.width >= 160,
+                      window.frame.height >= 100,
+                      let app = window.owningApplication,
+                      app.bundleIdentifier != ownBundleID,
+                      !isBlockedApplication(app),
+                      !isBlockedTitle(window.title, app: app) else {
+                    return false
+                }
+
+                return true
+            }
             .filter { window in
                 let key = dedupeKey(for: window)
                 guard !seenKeys.contains(key) else { return false }
@@ -65,27 +80,6 @@ final class RecordingSourceCatalog {
             .sorted { lhs, rhs in
                 windowTitle(lhs).localizedCaseInsensitiveCompare(windowTitle(rhs)) == .orderedAscending
             }
-    }
-
-    /// Windows suitable for spatial hit-testing in the recording setup overlay.
-    /// Preserves ScreenCaptureKit's source order instead of sorting by title.
-    static func pickableWindows(from content: SCShareableContent) -> [SCWindow] {
-        let ownBundleID = Bundle.main.bundleIdentifier
-
-        return content.windows.filter { window in
-            guard window.isOnScreen,
-                  window.windowLayer == 0,
-                  window.frame.width >= 160,
-                  window.frame.height >= 100,
-                  let app = window.owningApplication,
-                  app.bundleIdentifier != ownBundleID,
-                  !isBlockedApplication(app),
-                  !isBlockedTitle(window.title, app: app) else {
-                return false
-            }
-
-            return true
-        }
     }
 
     private static func isBlockedApplication(_ app: SCRunningApplication) -> Bool {

--- a/Screendrop/ScreendropPreferences.swift
+++ b/Screendrop/ScreendropPreferences.swift
@@ -35,6 +35,7 @@ enum ScreendropPreferences {
     static let overlayCardLayoutKey = "overlayCardLayout"
     static let lowResolutionEditorPreviewKey = "lowResolutionEditorPreview"
     static let trimFullscreenMenuBarKey = "trimFullscreenMenuBar"
+    static let showRecordingSetupHUDKey = "showRecordingSetupHUD"
 
     private static let defaultCompressionQuality = 0.8
     static let defaultRecordingMouseIndicatorColor = "#007AFF"
@@ -171,6 +172,15 @@ enum ScreendropPreferences {
         return UserDefaults.standard.bool(forKey: lowResolutionEditorPreviewKey)
     }
     
+    /// Whether the recording setup HUD (mode picker + region selection) is shown
+    /// before a recording starts.  Defaults to on.
+    static var showRecordingSetupHUD: Bool {
+        if UserDefaults.standard.object(forKey: showRecordingSetupHUDKey) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: showRecordingSetupHUDKey)
+    }
+
     /// Whether fullscreen captures on notched displays trim the empty black
     /// menu-bar strip at the top. The strip is only removed when it's solid
     /// black (menu bar hidden); a revealed menu bar is preserved. Defaults to on.

--- a/Screendrop/SettingsPlaceholderPanes.swift
+++ b/Screendrop/SettingsPlaceholderPanes.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftUI
 
 struct VideoSettingsPane: View {
+    @AppStorage(ScreendropPreferences.showRecordingSetupHUDKey) private var showSetupHUD = true
     @AppStorage(ScreendropPreferences.showRecordingMouseIndicatorsKey) private var showMouseIndicators = true
     @AppStorage(ScreendropPreferences.showRecordingKeyPressCaptionsKey) private var showKeyPressCaptions = false
     @AppStorage(ScreendropPreferences.recordingMouseIndicatorColorKey) private var mouseIndicatorColor = ScreendropPreferences.defaultRecordingMouseIndicatorColor
@@ -22,6 +23,18 @@ struct VideoSettingsPane: View {
 
     var body: some View {
         Form {
+            Section("Recording Setup") {
+                Toggle(isOn: $showSetupHUD) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show options before recording")
+                        Text("Opens a mode and region selector before recording starts. Turn off to record the full screen immediately.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
+            }
+
             CaptureHotkeySettingsSection(actions: [.screenRecording])
 
             AfterCaptureActionsSection(type: .recording, title: "After Recording")


### PR DESCRIPTION
## What

Every video recording trigger now opens a CleanShot-style setup overlay before recording begins. The recording menu is replaced by a single **Record Screen…** item that opens the HUD first.

### Two modes in one overlay

**Full Screen** — the entire display is highlighted with a border. Click anywhere or press Return to start recording.

**Area** — drag to draw a region; 8 handles resize it (corner handles lock to the chosen aspect ratio); drag the body to reposition. Aspect presets: Freeform / 16:9 / 9:16 / 1:1 / 4:3. Live W×H readout in the toolbar.

A floating toolbar (mode segmented control + aspect chips for Area + Start / Cancel) floats at the bottom of the display. Return and Esc keyboard shortcuts work throughout.

## Reversible default

A **Show options before recording** toggle in Settings → Video (defaults on) lets users revert to the previous "record full screen immediately" behavior without any code change. With the toggle off, `recordScreen()` falls back to the existing instant-fullscreen path.

## Part of a series

Builds on PRs #6 and #7 (adjustable area selection + aspect presets). This is the behavior-change PR — it is the only one that changes the default recording flow.

Window recording was intentionally removed from this PR for now after testing showed the custom window picker was not reliable enough. The app's screenshot window picker still uses native `screencapture -w`; video window picking can be revisited separately with a dedicated implementation.

## New file

`RecordingSetupPresenter.swift` — unified coordinator + `RecordingSetupOverlayView` (Full Screen / Area AppKit view) + `RecordingSetupKeyPanel`.

## Changed files

| File | Change |
|------|--------|
| `RecordingSetupModel.swift` | Added `mode` and `canStart` for Full Screen / Area |
| `RecordingSetupToolbarView.swift` | Mode segmented control; aspect chips/readout shown only in Area |
| `RecordingAreaSelectionPresenter.swift` | Wired `onModeChange:` (no-op — mode switching is handled by the new presenter) |
| `CaptureCoordinator.swift` | `recordScreen()` routes through `RecordingSetupPresenter` when HUD is enabled |
| `MenuBarView.swift` | Collapsed recording menu to one "Record Screen…" button |
| `ScreendropPreferences.swift` | `showRecordingSetupHUDKey` preference (defaults on) |
| `SettingsPlaceholderPanes.swift` | "Show options before recording" toggle in Video pane |

## Scope

- The capture pipeline (`ScreenRecordingSource`, `ScreenRecordingManager`, `SCStreamConfiguration`) is unchanged.
- Setup HUD currently supports **Full Screen** and **Area** only.
- Existing direct window-recording helper code is not part of this HUD and will be handled/cleaned up separately.
- `RecordingAreaSelectionPresenter` still exists; it will be retired in a follow-up cleanup PR once all area entry points route through the new presenter.

## Testing

- `xcodebuild -scheme Screendrop -configuration Debug -destination 'platform=macOS'` → **BUILD SUCCEEDED**.
- Manual: Option+4 / menu "Record Screen…" → HUD opens; mode picker switches between Full Screen and Area; Area drag + handles + presets works; Full Screen click confirms; Esc cancels; toggle off in Settings → immediate fullscreen.

## Demo

_Screen recording to be added._