### PR TITLE
Add draggable screenshot baskets

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ New captures appear as floating cards on the active display. From a card you can
 - Upload to your cloud and copy the link.
 - Delete the file or dismiss only the preview.
 - Copy recognized text from a screenshot using on-device OCR.
+- Add screenshots to a basket and drag the complete basket into another app as separate files.
 
 The overlay can appear on the left or right, close automatically after a chosen delay, and dismiss after a drag. Its actions are completely rearrangeable: drag actions between four corner slots, the center buttons, and a hidden-actions tray in **Settings → Overlay**.
 
@@ -130,7 +131,7 @@ When the stack is collapsed, it becomes a small peek tab instead of disappearing
 
 ### History
 
-History keeps screenshots and complete recording projects together. It shows thumbnails, dimensions, capture times, video durations, editable-project state, and saved cloud links.
+History keeps screenshots and complete recording projects together. It shows thumbnails, dimensions, capture times, video durations, editable-project state, and saved cloud links. Select any number of screenshots in History to add them to the same draggable basket used by the floating preview.
 
 From History you can Quick Look, copy, annotate, edit, upload, reveal in Finder, or delete a capture. The menu bar also exposes a compact list of recent items.
 

--- a/Screendrop/OverlayCardLayout.swift
+++ b/Screendrop/OverlayCardLayout.swift
@@ -16,6 +16,7 @@ import Foundation
 /// Every action that can be placed on the preview card.
 enum OverlayCardAction: String, CaseIterable, Codable, Identifiable {
     case copy
+    case basket
     case compress
     case save
     case pin
@@ -31,6 +32,7 @@ enum OverlayCardAction: String, CaseIterable, Codable, Identifiable {
     func symbol(for kind: PreviewMediaKind = .image) -> String {
         switch self {
         case .copy: "doc.on.doc"
+        case .basket: "basket"
         case .compress: "arrow.down.right.and.arrow.up.left"
         case .save: "square.and.arrow.down"
         case .pin: "pin.fill"
@@ -47,6 +49,7 @@ enum OverlayCardAction: String, CaseIterable, Codable, Identifiable {
     func label(for kind: PreviewMediaKind = .image) -> String {
         switch self {
         case .copy: "Copy"
+        case .basket: "Basket"
         case .compress: "Compress"
         case .save: "Save"
         case .pin: "Pin"
@@ -62,6 +65,7 @@ enum OverlayCardAction: String, CaseIterable, Codable, Identifiable {
     func help(for kind: PreviewMediaKind = .image) -> String {
         switch self {
         case .copy: "Copy to clipboard"
+        case .basket: "Add to or remove from the screenshot basket"
         case .compress: "Copy a compressed JPG"
         case .save: "Save to disk"
         case .pin: "Pin to screen"
@@ -77,6 +81,7 @@ enum OverlayCardAction: String, CaseIterable, Codable, Identifiable {
     var detail: String {
         switch self {
         case .copy: "Copy the capture to the clipboard"
+        case .basket: "Collect the screenshot for one multi-file drag"
         case .compress: "Copy a smaller JPG to the clipboard"
         case .save: "Save the capture to your export folder"
         case .pin: "Pin the screenshot as a floating window"
@@ -120,15 +125,15 @@ struct OverlayCardLayout: Codable, Equatable {
     /// Actions that are not shown on the card.
     var hidden: [OverlayCardAction]
 
-    /// Matches the original hard-coded card layout, with the new `view` action
-    /// tucked away in the hidden tray so existing behaviour is unchanged.
+    /// Keeps the most common capture actions visible by default. Less frequent
+    /// actions remain available in the hidden tray and can be rearranged.
     static let `default` = OverlayCardLayout(
         topLeading: .delete,
         topTrailing: .close,
         bottomLeading: .annotate,
         bottomTrailing: .upload,
-        center: [.copy, .save, .pin],
-        hidden: [.view, .compress]
+        center: [.copy, .save, .basket],
+        hidden: [.view, .compress, .pin]
     )
 
     // MARK: - Reads

--- a/Screendrop/OverlayCardLayoutStore.swift
+++ b/Screendrop/OverlayCardLayoutStore.swift
@@ -36,7 +36,23 @@ final class OverlayCardLayoutStore {
         else {
             return .default
         }
+
+        // Surface Basket for users who still have the previous untouched
+        // default. Never rearrange a layout the user has customized.
+        if isLegacyDefault(decoded) {
+            return .default
+        }
+
         return decoded.normalized()
+    }
+
+    private static func isLegacyDefault(_ layout: OverlayCardLayout) -> Bool {
+        layout.topLeading == .delete
+            && layout.topTrailing == .close
+            && layout.bottomLeading == .annotate
+            && layout.bottomTrailing == .upload
+            && layout.center == [.copy, .save, .pin]
+            && layout.hidden == [.view, .compress]
     }
 
     private func persist() {

--- a/Screendrop/PreviewCardView.swift
+++ b/Screendrop/PreviewCardView.swift
@@ -65,7 +65,22 @@ struct PreviewCardView: View {
             .clipShape(.rect(cornerRadius: cornerRadius))
             .overlay {
                 RoundedRectangle(cornerRadius: cornerRadius)
-                    .strokeBorder(.white.opacity(0.25), lineWidth: 1)
+                    .strokeBorder(
+                        isInBasket ? Color.accentColor : .white.opacity(0.25),
+                        lineWidth: isInBasket ? 3 : 1
+                    )
+            }
+            .overlay(alignment: .topTrailing) {
+                if isInBasket && !showOverlay {
+                    Image(systemName: "basket.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(6)
+                        .background(Color.accentColor, in: Circle())
+                        .padding(8)
+                        .transition(.scale.combined(with: .opacity))
+                        .accessibilityLabel("In screenshot basket")
+                }
             }
             // Flatten the rounded-clipped image + border into a single layer so
             // the collapse/expand offset animation transforms the already-rounded
@@ -121,6 +136,16 @@ struct PreviewCardView: View {
                 }
             }
             .simultaneousGesture(
+                TapGesture().onEnded {
+                    let modifiers = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                    guard item.kind == .image, modifiers.contains(.shift) else { return }
+
+                    withAnimation(previewStackAnimation) {
+                        onToggleBasket()
+                    }
+                }
+            )
+            .simultaneousGesture(
                 TapGesture(count: 2).onEnded {
                     if item.kind == .video {
                         onEditVideo()
@@ -148,6 +173,11 @@ struct PreviewCardView: View {
                     Button("Copy Text from Image") { onCopyText() }
                 }
             }
+            .help(item.kind == .image ? "Shift-click to add or remove from Basket" : "Double-click to edit recording")
+    }
+
+    private var isInBasket: Bool {
+        item.kind == .image && basket.contains(item.url)
     }
 
     private var layout: OverlayCardLayout {

--- a/Screendrop/PreviewCardView.swift
+++ b/Screendrop/PreviewCardView.swift
@@ -29,6 +29,7 @@ struct PreviewCardView: View {
     let onView: () -> Void
     let onCompress: () -> Void
     let onCopyText: () -> Void
+    let onToggleBasket: () -> Void
     let onDragBegan: () -> Void
     let onDragEnded: () -> Void
 
@@ -36,6 +37,7 @@ struct PreviewCardView: View {
     @State private var isPresented = false
     @State private var cloudUploader = CloudUploader.shared
     @State private var layoutStore = OverlayCardLayoutStore.shared
+    @State private var basket = ScreenshotBasket.shared
     @State private var shakeOffset: CGFloat = 0
     @State private var showUploadFailed = false
     @State private var showCheckmark = false
@@ -139,6 +141,10 @@ struct PreviewCardView: View {
             .animation(previewStackAnimation, value: isDismissing)
             .contextMenu {
                 if item.kind == .image {
+                    Button(basket.contains(item.url) ? "Remove from Basket" : "Add to Basket") {
+                        onToggleBasket()
+                    }
+                    Divider()
                     Button("Copy Text from Image") { onCopyText() }
                 }
             }
@@ -197,8 +203,12 @@ struct PreviewCardView: View {
             cloudCornerButton
         } else {
             cornerButton(
-                systemImage: action.symbol(for: item.kind),
-                help: action.help(for: item.kind),
+                systemImage: action == .basket && basket.contains(item.url)
+                    ? "basket.fill"
+                    : action.symbol(for: item.kind),
+                help: action == .basket && basket.contains(item.url)
+                    ? "Remove from screenshot basket"
+                    : action.help(for: item.kind),
                 action: handler(for: action)
             )
         }
@@ -227,6 +237,8 @@ struct PreviewCardView: View {
     private func centerPill(for action: OverlayCardAction) -> some View {
         if action == .upload, cloudUploader.uploadedURLs[item.id] != nil {
             actionPill("Copy Link", action: copyUploadedURL)
+        } else if action == .basket {
+            actionPill(basket.contains(item.url) ? "In Basket" : "Add to Basket", action: onToggleBasket)
         } else {
             actionPill(action.label(for: item.kind), action: handler(for: action))
         }
@@ -235,7 +247,7 @@ struct PreviewCardView: View {
     /// Whether an action should be shown for the current item.
     private func isAvailable(_ action: OverlayCardAction) -> Bool {
         switch action {
-        case .pin, .compress: item.kind == .image
+        case .pin, .compress, .basket: item.kind == .image
         case .upload: cloudUploader.isConfigured
         default: true
         }
@@ -244,6 +256,7 @@ struct PreviewCardView: View {
     private func handler(for action: OverlayCardAction) -> () -> Void {
         switch action {
         case .copy: onCopy
+        case .basket: onToggleBasket
         case .compress: onCompress
         case .save: onSave
         case .pin: onPin

--- a/Screendrop/PreviewPanelPresenter.swift
+++ b/Screendrop/PreviewPanelPresenter.swift
@@ -29,7 +29,8 @@ final class PreviewPanelPresenter {
     }
 
     func closeIfEmpty() {
-        guard ScreenshotPreviewStack.shared.items.isEmpty else { return }
+        guard ScreenshotPreviewStack.shared.items.isEmpty,
+              ScreenshotBasket.shared.isEmpty else { return }
 
         QuickLookPreviewPresenter.dismiss()
         destroyPanel()

--- a/Screendrop/PreviewWindowView.swift
+++ b/Screendrop/PreviewWindowView.swift
@@ -23,6 +23,7 @@ struct PreviewWindowView: View {
     private let onEditVideo: ((URL) -> Void)?
 
     @State private var previewStack = ScreenshotPreviewStack.shared
+    @State private var basket = ScreenshotBasket.shared
     @State private var keyMonitor: Any?
     @State private var globalKeyMonitor: Any?
     @State private var scrollMonitor: Any?
@@ -90,6 +91,18 @@ struct PreviewWindowView: View {
                     .padding(.leading, previewPosition == .left ? peekHorizontalPadding : 0)
                     .padding(.trailing, previewPosition == .right ? peekHorizontalPadding : 0)
                     .offset(y: peekIsVisible ? 0 : peekHiddenOffset)
+
+                if !basket.isEmpty {
+                    ScreenshotBasketShelf()
+                        // Capture the shelf's tight bounds before the outer
+                        // positioning frame expands to the full-screen panel.
+                        .reportsInteractiveRect(active: !previewStack.isExiting)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: stackAlignment)
+                        .padding(.leading, previewPosition == .left ? basketHorizontalPadding : 0)
+                        .padding(.trailing, previewPosition == .right ? basketHorizontalPadding : 0)
+                        .padding(.bottom, previewStackEdgePadding)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
             // Only animate card add/remove while the stack is expanded. When
             // collapsed the stack is slid off-screen and its hidden offset is
@@ -136,13 +149,12 @@ struct PreviewWindowView: View {
         }
         .onDisappear(perform: tearDown)
         .onChange(of: previewStack.items.count) { _, count in
-            if count == 0 {
-                if let onRequestClose {
-                    onRequestClose()
-                } else {
-                    dismissWindow()
-                }
-            }
+            guard count == 0 else { return }
+            closeIfEmpty()
+        }
+        .onChange(of: basket.count) { _, count in
+            guard count == 0 else { return }
+            closeIfEmpty()
         }
     }
 
@@ -230,6 +242,9 @@ struct PreviewWindowView: View {
                     onCopyText: {
                         previewStack.copyText(id: item.id)
                     },
+                    onToggleBasket: {
+                        basket.toggle(item.url)
+                    },
                     onDragBegan: {
                         previewStack.beginDrag(id: item.id)
                     },
@@ -279,6 +294,12 @@ struct PreviewWindowView: View {
     /// the cards to line up on the same x-position.
     private var peekHorizontalPadding: CGFloat {
         previewTrailingPadding
+    }
+
+    /// The basket sits immediately inward from the card column, so it remains
+    /// available whether the preview stack is expanded or tucked into peek.
+    private var basketHorizontalPadding: CGFloat {
+        previewTrailingPadding + previewCardSize.width + 12
     }
 
     /// Distance to slide the stack straight down so it clears the bottom edge
@@ -391,6 +412,16 @@ struct PreviewWindowView: View {
             withAnimation(.easeOut(duration: 0.18)) {
                 isOverlayTransitioning = false
             }
+        }
+    }
+
+    private func closeIfEmpty() {
+        guard previewStack.items.isEmpty, basket.isEmpty else { return }
+
+        if let onRequestClose {
+            onRequestClose()
+        } else {
+            dismissWindow()
         }
     }
     

--- a/Screendrop/ScreenshotBasket.swift
+++ b/Screendrop/ScreenshotBasket.swift
@@ -1,0 +1,362 @@
+//
+//  ScreenshotBasket.swift
+//  Screendrop
+//
+//  A lightweight, session-scoped collection of screenshots that can be
+//  dragged to another app as one multi-file operation.
+//
+
+import AppKit
+import Observation
+import SwiftUI
+import UniformTypeIdentifiers
+
+@MainActor
+@Observable
+final class ScreenshotBasket {
+    static let shared = ScreenshotBasket()
+
+    private(set) var urls: [URL] = []
+
+    var count: Int { urls.count }
+    var isEmpty: Bool { urls.isEmpty }
+
+    private init() {}
+
+    func contains(_ url: URL) -> Bool {
+        let candidate = url.standardizedFileURL
+        return urls.contains { $0.standardizedFileURL == candidate }
+    }
+
+    func add(_ url: URL) {
+        add(contentsOf: [url])
+    }
+
+    func add(contentsOf newURLs: [URL]) {
+        var knownURLs = Set(urls.map(\.standardizedFileURL))
+
+        for url in newURLs {
+            let standardizedURL = url.standardizedFileURL
+            guard FileManager.default.fileExists(atPath: standardizedURL.path),
+                  isImageURL(standardizedURL),
+                  knownURLs.insert(standardizedURL).inserted else {
+                continue
+            }
+            urls.append(standardizedURL)
+        }
+    }
+
+    func toggle(_ url: URL) {
+        if contains(url) {
+            remove(url)
+        } else {
+            add(url)
+        }
+    }
+
+    func remove(_ url: URL) {
+        let candidate = url.standardizedFileURL
+        urls.removeAll { $0.standardizedFileURL == candidate }
+    }
+
+    func remove(contentsOf removedURLs: [URL]) {
+        let candidates = Set(removedURLs.map(\.standardizedFileURL))
+        urls.removeAll { candidates.contains($0.standardizedFileURL) }
+    }
+
+    func clear() {
+        urls.removeAll()
+    }
+
+    /// Removes history entries that were deleted while the basket was open.
+    func pruneMissingFiles() {
+        urls.removeAll { !FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    @discardableResult
+    func copyAllToClipboard() -> Bool {
+        pruneMissingFiles()
+        guard !urls.isEmpty else { return false }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        return pasteboard.writeObjects(urls.map(Self.pasteboardItem(for:)))
+    }
+
+    static func pasteboardItem(for url: URL) -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        item.setString(url.absoluteString, forType: .fileURL)
+        return item
+    }
+
+    private func isImageURL(_ url: URL) -> Bool {
+        UTType(filenameExtension: url.pathExtension)?.conforms(to: .image) == true
+    }
+}
+
+/// A reusable basket pill. Clicking it opens the contents, while dragging its
+/// main surface starts one AppKit drag session containing every screenshot URL.
+struct ScreenshotBasketShelf: View {
+    @State private var basket = ScreenshotBasket.shared
+    @State private var showsContents = false
+
+    private let width: CGFloat = 165
+    private let height: CGFloat = 44
+
+    var body: some View {
+        ZStack {
+            shelfBackground
+
+            HStack(spacing: 0) {
+                Button {
+                    showsContents = true
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "basket.fill")
+                            .font(.system(size: 13, weight: .semibold))
+
+                        Text("\(basket.count) in Basket")
+                            .font(.system(size: 12, weight: .medium))
+                            .lineLimit(1)
+
+                        Spacer(minLength: 0)
+                    }
+                    .contentShape(Rectangle())
+                    .padding(.leading, 13)
+                    .padding(.trailing, 8)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Review screenshot basket")
+                .accessibilityHint("Contains \(basket.count) screenshots")
+
+                Divider()
+                    .frame(height: 16)
+
+                Button {
+                    basket.clear()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .frame(width: 24, height: 24)
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .help("Clear basket")
+            }
+            .foregroundStyle(.secondary)
+            .padding(.trailing, 7)
+
+            HStack(spacing: 0) {
+                ScreenshotBasketDragSource(
+                    urls: basket.urls,
+                    onClick: { showsContents = true }
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .help("Drag all screenshots, or click to review the basket")
+                .accessibilityHidden(true)
+
+                Color.clear
+                    .frame(width: 39)
+                    .allowsHitTesting(false)
+            }
+        }
+        .frame(width: width, height: height)
+        .popover(isPresented: $showsContents, arrowEdge: .top) {
+            ScreenshotBasketContentsView()
+        }
+        .onAppear {
+            basket.pruneMissingFiles()
+        }
+    }
+
+    private var shelfBackground: some View {
+        let shape = RoundedRectangle(cornerRadius: 14, style: .continuous)
+        return Color.clear
+            .glassEffect(.regular.interactive(), in: shape)
+            .overlay {
+                shape.strokeBorder(.white.opacity(0.25), lineWidth: 1)
+            }
+    }
+}
+
+private struct ScreenshotBasketContentsView: View {
+    @State private var basket = ScreenshotBasket.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Screenshot Basket", systemImage: "basket.fill")
+                    .font(.headline)
+
+                Spacer()
+
+                Text("\(basket.count)")
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+
+                Button("Copy All", systemImage: "doc.on.doc") {
+                    basket.copyAllToClipboard()
+                }
+                .help("Copy all screenshot files")
+            }
+            .padding(14)
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(basket.urls, id: \.self) { url in
+                        HStack(spacing: 10) {
+                            Image(systemName: "photo")
+                                .foregroundStyle(.secondary)
+                                .frame(width: 20)
+
+                            Text(url.lastPathComponent)
+                                .font(.system(size: 12))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+
+                            Spacer(minLength: 8)
+
+                            Button {
+                                basket.remove(url)
+                            } label: {
+                                Image(systemName: "minus.circle")
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Remove from basket")
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                    }
+                }
+            }
+            .frame(width: 320, height: min(CGFloat(basket.count) * 38, 260))
+        }
+        .onAppear {
+            basket.pruneMissingFiles()
+        }
+    }
+}
+
+private struct ScreenshotBasketDragSource: NSViewRepresentable {
+    let urls: [URL]
+    let onClick: () -> Void
+
+    func makeNSView(context: Context) -> BasketDragSourceView {
+        BasketDragSourceView()
+    }
+
+    func updateNSView(_ nsView: BasketDragSourceView, context: Context) {
+        nsView.urls = urls
+        nsView.onClick = onClick
+        nsView.onMissingURLs = { ScreenshotBasket.shared.remove(contentsOf: $0) }
+    }
+
+    static func dismantleNSView(_ nsView: BasketDragSourceView, coordinator: Void) {
+        nsView.urls = []
+        nsView.onClick = nil
+        nsView.onMissingURLs = nil
+    }
+}
+
+private final class BasketDragSourceView: NSView, NSDraggingSource {
+    var urls: [URL] = []
+    var onClick: (() -> Void)?
+    var onMissingURLs: (([URL]) -> Void)?
+
+    private var mouseDownPoint: NSPoint?
+    private var startedDragging = false
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        mouseDownPoint = convert(event.locationInWindow, from: nil)
+        startedDragging = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard !startedDragging,
+              let mouseDownPoint else {
+            return
+        }
+
+        let currentPoint = convert(event.locationInWindow, from: nil)
+        guard hypot(currentPoint.x - mouseDownPoint.x, currentPoint.y - mouseDownPoint.y) >= 4 else {
+            return
+        }
+
+        let validURLs = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
+        let missingURLs = urls.filter { !FileManager.default.fileExists(atPath: $0.path) }
+        if !missingURLs.isEmpty {
+            onMissingURLs?(missingURLs)
+        }
+        guard !validURLs.isEmpty else { return }
+
+        startedDragging = true
+        let previewImage = Self.dragPreviewImage(count: validURLs.count)
+        let previewFrame = NSRect(
+            x: currentPoint.x - 34,
+            y: currentPoint.y - 25,
+            width: 68,
+            height: 50
+        )
+        let draggingItems = validURLs.map { url in
+            let item = NSDraggingItem(pasteboardWriter: ScreenshotBasket.pasteboardItem(for: url))
+            item.setDraggingFrame(previewFrame, contents: previewImage)
+            return item
+        }
+
+        let session = beginDraggingSession(with: draggingItems, event: event, source: self)
+        session.draggingFormation = .stack
+        session.animatesToStartingPositionsOnCancelOrFail = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        defer {
+            mouseDownPoint = nil
+            startedDragging = false
+        }
+
+        if !startedDragging {
+            onClick?()
+        }
+    }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        .copy
+    }
+
+    func ignoreModifierKeys(for session: NSDraggingSession) -> Bool {
+        true
+    }
+
+    private static func dragPreviewImage(count: Int) -> NSImage {
+        let size = NSSize(width: 68, height: 50)
+        let image = NSImage(size: size)
+        image.lockFocus()
+
+        NSColor.windowBackgroundColor.withAlphaComponent(0.94).setFill()
+        NSBezierPath(roundedRect: NSRect(origin: .zero, size: size), xRadius: 12, yRadius: 12).fill()
+
+        let symbol = NSImage(systemSymbolName: "photo.on.rectangle.angled", accessibilityDescription: nil)
+        symbol?.draw(in: NSRect(x: 10, y: 13, width: 24, height: 24))
+
+        let text = "\(count)"
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 14, weight: .semibold),
+            .foregroundColor: NSColor.labelColor
+        ]
+        let textSize = text.size(withAttributes: attributes)
+        text.draw(
+            at: NSPoint(x: 47 - textSize.width / 2, y: 25 - textSize.height / 2),
+            withAttributes: attributes
+        )
+
+        image.unlockFocus()
+        return image
+    }
+}

--- a/Screendrop/ScreenshotHistoryStore.swift
+++ b/Screendrop/ScreenshotHistoryStore.swift
@@ -370,6 +370,8 @@ final class ScreenshotHistoryStore {
     }
 
     func delete(_ item: ScreenshotHistoryItem) {
+        ScreenshotBasket.shared.remove(item.url)
+
         let auxiliaryURLs: [URL]
         if let recordingSession = item.recordingSession {
             auxiliaryURLs = [recordingSession.directoryURL]

--- a/Screendrop/ScreenshotPreviewStack.swift
+++ b/Screendrop/ScreenshotPreviewStack.swift
@@ -477,6 +477,8 @@ final class ScreenshotPreviewStack {
     func deleteScreenshot(id: ScreenshotPreviewItem.ID) {
         guard let item = items.first(where: { $0.id == id }) else { return }
 
+        ScreenshotBasket.shared.remove(item.url)
+
         if ScreenshotHistoryStore.shared.delete(url: item.url) {
             // The history store owns this file and has already removed it.
         } else {

--- a/Screendrop/SettingsHistoryPane.swift
+++ b/Screendrop/SettingsHistoryPane.swift
@@ -10,6 +10,7 @@ struct SettingsHistoryPane: View {
     @State private var historyStore = ScreenshotHistoryStore.shared
     @State private var basket = ScreenshotBasket.shared
     @State private var selectedScreenshotIDs: Set<ScreenshotHistoryItem.ID> = []
+    @State private var selectionAnchorID: ScreenshotHistoryItem.ID?
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
@@ -33,8 +34,8 @@ struct SettingsHistoryPane: View {
                                 item: item,
                                 isSelected: selectedScreenshotIDs.contains(item.id),
                                 isInBasket: basket.contains(item.url),
-                                onToggleSelection: {
-                                    toggleSelection(for: item)
+                                onSelect: { extendsRange in
+                                    select(item, extendsRange: extendsRange)
                                 },
                                 onToggleBasket: {
                                     toggleBasket(for: item)
@@ -65,6 +66,10 @@ struct SettingsHistoryPane: View {
                                 },
                                 onDelete: {
                                     selectedScreenshotIDs.remove(item.id)
+                                    if selectionAnchorID == item.id {
+                                        selectionAnchorID = nil
+                                    }
+                                    basket.remove(item.url)
                                     historyStore.delete(item)
                                 }
                             )
@@ -79,6 +84,11 @@ struct SettingsHistoryPane: View {
             }
         }
         .scrollEdgeEffectSoftIfAvailable()
+        .background {
+            HistoryKeyboardShortcutMonitor {
+                selectAllScreenshots()
+            }
+        }
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 Button {
@@ -92,6 +102,11 @@ struct SettingsHistoryPane: View {
         .onAppear {
             historyStore.reload()
             selectedScreenshotIDs.formIntersection(historyStore.items.map(\.id))
+            if let selectionAnchorID,
+               !selectedScreenshotIDs.contains(selectionAnchorID) {
+                self.selectionAnchorID = nil
+            }
+            basket.pruneMissingFiles()
         }
     }
 
@@ -102,17 +117,15 @@ struct SettingsHistoryPane: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 
+                if !screenshotItems.isEmpty {
+                    Text("Shift-click for a range. ⌘A selects all screenshots.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+
                 Spacer()
 
                 if !screenshotItems.isEmpty {
-                    Button(allScreenshotsAreSelected ? "Deselect All" : "Select All") {
-                        if allScreenshotsAreSelected {
-                            selectedScreenshotIDs.removeAll()
-                        } else {
-                            selectedScreenshotIDs = Set(screenshotItems.map(\.id))
-                        }
-                    }
-
                     Button("Add \(selectedScreenshotIDs.count) to Basket", systemImage: "basket") {
                         addSelectionToBasket()
                     }
@@ -142,17 +155,30 @@ struct SettingsHistoryPane: View {
         historyStore.items.filter { !$0.isVideo }
     }
 
-    private var allScreenshotsAreSelected: Bool {
-        !screenshotItems.isEmpty && screenshotItems.allSatisfy { selectedScreenshotIDs.contains($0.id) }
-    }
-
-    private func toggleSelection(for item: ScreenshotHistoryItem) {
+    private func select(_ item: ScreenshotHistoryItem, extendsRange: Bool) {
         guard !item.isVideo else { return }
+
+        if extendsRange,
+           let selectionAnchorID,
+           let anchorIndex = screenshotItems.firstIndex(where: { $0.id == selectionAnchorID }),
+           let itemIndex = screenshotItems.firstIndex(where: { $0.id == item.id }) {
+            let range = min(anchorIndex, itemIndex)...max(anchorIndex, itemIndex)
+            selectedScreenshotIDs.formUnion(screenshotItems[range].map(\.id))
+            return
+        }
+
         if selectedScreenshotIDs.contains(item.id) {
             selectedScreenshotIDs.remove(item.id)
         } else {
             selectedScreenshotIDs.insert(item.id)
         }
+        selectionAnchorID = item.id
+    }
+
+    private func selectAllScreenshots() {
+        guard !screenshotItems.isEmpty else { return }
+        selectedScreenshotIDs = Set(screenshotItems.map(\.id))
+        selectionAnchorID = screenshotItems.first?.id
     }
 
     private func addSelectionToBasket() {
@@ -161,6 +187,7 @@ struct SettingsHistoryPane: View {
             .map(\.url)
         basket.add(contentsOf: selectedURLs)
         selectedScreenshotIDs.removeAll()
+        selectionAnchorID = nil
 
         if !basket.isEmpty {
             PreviewPanelPresenter.shared.show(displayID: nil)
@@ -194,11 +221,76 @@ struct SettingsHistoryPane: View {
     }
 }
 
+private struct HistoryKeyboardShortcutMonitor: NSViewRepresentable {
+    let onSelectAll: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        context.coordinator.view = view
+        context.coordinator.startMonitoring()
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.parent = self
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.stopMonitoring()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var parent: HistoryKeyboardShortcutMonitor
+        weak var view: NSView?
+        private var eventMonitor: Any?
+
+        init(parent: HistoryKeyboardShortcutMonitor) {
+            self.parent = parent
+        }
+
+        func startMonitoring() {
+            guard eventMonitor == nil else { return }
+            eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                guard let self,
+                      event.window === view?.window,
+                      modifiers.contains(.command),
+                      modifiers.intersection([.control, .option, .shift]).isEmpty,
+                      event.charactersIgnoringModifiers?.lowercased() == "a",
+                      !(event.window?.firstResponder is NSTextView) else {
+                    return event
+                }
+
+                parent.onSelectAll()
+                return nil
+            }
+        }
+
+        func stopMonitoring() {
+            if let eventMonitor {
+                NSEvent.removeMonitor(eventMonitor)
+                self.eventMonitor = nil
+            }
+        }
+
+        deinit {
+            if let eventMonitor {
+                NSEvent.removeMonitor(eventMonitor)
+            }
+        }
+    }
+}
+
 private struct SettingsHistoryItemRow: View {
     let item: ScreenshotHistoryItem
     let isSelected: Bool
     let isInBasket: Bool
-    let onToggleSelection: () -> Void
+    let onSelect: (_ extendsRange: Bool) -> Void
     let onToggleBasket: () -> Void
     let onPreview: () -> Void
     let onCopy: () -> Void
@@ -219,7 +311,9 @@ private struct SettingsHistoryItemRow: View {
                 Color.clear
                     .frame(width: 18, height: 18)
             } else {
-                Button(action: onToggleSelection) {
+                Button {
+                    onSelect(NSEvent.modifierFlags.contains(.shift))
+                } label: {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .font(.system(size: 16))
                         .foregroundStyle(isSelected ? Color.accentColor : .secondary)
@@ -329,6 +423,10 @@ private struct SettingsHistoryItemRow: View {
         .padding(.horizontal, 18)
         .padding(.vertical, 10)
         .contentShape(Rectangle())
+        .onTapGesture {
+            guard !item.isVideo, NSEvent.modifierFlags.contains(.shift) else { return }
+            onSelect(true)
+        }
         .onHover { hovering in
             isHovering = hovering
         }

--- a/Screendrop/SettingsHistoryPane.swift
+++ b/Screendrop/SettingsHistoryPane.swift
@@ -118,7 +118,7 @@ struct SettingsHistoryPane: View {
                     .foregroundStyle(.secondary)
 
                 if !screenshotItems.isEmpty {
-                    Text("Shift-click for a range. ⌘A selects all screenshots.")
+                    Text("Shift-click for a range. ⌘A selects or deselects all screenshots.")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
@@ -176,9 +176,16 @@ struct SettingsHistoryPane: View {
     }
 
     private func selectAllScreenshots() {
-        guard !screenshotItems.isEmpty else { return }
-        selectedScreenshotIDs = Set(screenshotItems.map(\.id))
-        selectionAnchorID = screenshotItems.first?.id
+        let screenshotIDs = Set(screenshotItems.map(\.id))
+        guard !screenshotIDs.isEmpty else { return }
+
+        if screenshotIDs.isSubset(of: selectedScreenshotIDs) {
+            selectedScreenshotIDs.removeAll()
+            selectionAnchorID = nil
+        } else {
+            selectedScreenshotIDs = screenshotIDs
+            selectionAnchorID = screenshotItems.first?.id
+        }
     }
 
     private func addSelectionToBasket() {

--- a/Screendrop/SettingsHistoryPane.swift
+++ b/Screendrop/SettingsHistoryPane.swift
@@ -8,11 +8,17 @@ import SwiftUI
 
 struct SettingsHistoryPane: View {
     @State private var historyStore = ScreenshotHistoryStore.shared
+    @State private var basket = ScreenshotBasket.shared
+    @State private var selectedScreenshotIDs: Set<ScreenshotHistoryItem.ID> = []
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
+                if !historyStore.items.isEmpty || !basket.isEmpty {
+                    historySelectionControls
+                }
+
                 if historyStore.items.isEmpty {
                     ContentUnavailableView(
                         "No Captures",
@@ -21,17 +27,18 @@ struct SettingsHistoryPane: View {
                     )
                     .frame(maxWidth: .infinity, minHeight: 360)
                 } else {
-                    Text("\(historyStore.items.count) capture\(historyStore.items.count == 1 ? "" : "s")")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 18)
-                        .padding(.top, 16)
-                        .padding(.bottom, 8)
-
                     LazyVStack(spacing: 0) {
                         ForEach(historyStore.items) { item in
                             SettingsHistoryItemRow(
                                 item: item,
+                                isSelected: selectedScreenshotIDs.contains(item.id),
+                                isInBasket: basket.contains(item.url),
+                                onToggleSelection: {
+                                    toggleSelection(for: item)
+                                },
+                                onToggleBasket: {
+                                    toggleBasket(for: item)
+                                },
                                 onPreview: {
                                     QuickLookPreviewPresenter.show(url: item.url)
                                 },
@@ -57,13 +64,14 @@ struct SettingsHistoryPane: View {
                                     historyStore.reveal(item)
                                 },
                                 onDelete: {
+                                    selectedScreenshotIDs.remove(item.id)
                                     historyStore.delete(item)
                                 }
                             )
 
                             if item.id != historyStore.items.last?.id {
                                 Divider()
-                                    .padding(.leading, 92)
+                                    .padding(.leading, 124)
                             }
                         }
                     }
@@ -83,6 +91,87 @@ struct SettingsHistoryPane: View {
         }
         .onAppear {
             historyStore.reload()
+            selectedScreenshotIDs.formIntersection(historyStore.items.map(\.id))
+        }
+    }
+
+    private var historySelectionControls: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 10) {
+                Text("\(historyStore.items.count) capture\(historyStore.items.count == 1 ? "" : "s")")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if !screenshotItems.isEmpty {
+                    Button(allScreenshotsAreSelected ? "Deselect All" : "Select All") {
+                        if allScreenshotsAreSelected {
+                            selectedScreenshotIDs.removeAll()
+                        } else {
+                            selectedScreenshotIDs = Set(screenshotItems.map(\.id))
+                        }
+                    }
+
+                    Button("Add \(selectedScreenshotIDs.count) to Basket", systemImage: "basket") {
+                        addSelectionToBasket()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(selectedScreenshotIDs.isEmpty)
+                }
+            }
+
+            if !basket.isEmpty {
+                HStack {
+                    Text("Drag the basket to attach all screenshots at once.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    ScreenshotBasketShelf()
+                }
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 16)
+        .padding(.bottom, 8)
+    }
+
+    private var screenshotItems: [ScreenshotHistoryItem] {
+        historyStore.items.filter { !$0.isVideo }
+    }
+
+    private var allScreenshotsAreSelected: Bool {
+        !screenshotItems.isEmpty && screenshotItems.allSatisfy { selectedScreenshotIDs.contains($0.id) }
+    }
+
+    private func toggleSelection(for item: ScreenshotHistoryItem) {
+        guard !item.isVideo else { return }
+        if selectedScreenshotIDs.contains(item.id) {
+            selectedScreenshotIDs.remove(item.id)
+        } else {
+            selectedScreenshotIDs.insert(item.id)
+        }
+    }
+
+    private func addSelectionToBasket() {
+        let selectedURLs = screenshotItems
+            .filter { selectedScreenshotIDs.contains($0.id) }
+            .map(\.url)
+        basket.add(contentsOf: selectedURLs)
+        selectedScreenshotIDs.removeAll()
+
+        if !basket.isEmpty {
+            PreviewPanelPresenter.shared.show(displayID: nil)
+        }
+    }
+
+    private func toggleBasket(for item: ScreenshotHistoryItem) {
+        guard !item.isVideo else { return }
+        basket.toggle(item.url)
+        if basket.contains(item.url) {
+            PreviewPanelPresenter.shared.show(displayID: nil)
         }
     }
 
@@ -107,6 +196,10 @@ struct SettingsHistoryPane: View {
 
 private struct SettingsHistoryItemRow: View {
     let item: ScreenshotHistoryItem
+    let isSelected: Bool
+    let isInBasket: Bool
+    let onToggleSelection: () -> Void
+    let onToggleBasket: () -> Void
     let onPreview: () -> Void
     let onCopy: () -> Void
     let onEdit: () -> Void
@@ -122,6 +215,19 @@ private struct SettingsHistoryItemRow: View {
 
     var body: some View {
         HStack(spacing: 14) {
+            if item.isVideo {
+                Color.clear
+                    .frame(width: 18, height: 18)
+            } else {
+                Button(action: onToggleSelection) {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 16))
+                        .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+                }
+                .buttonStyle(.plain)
+                .help(isSelected ? "Deselect screenshot" : "Select screenshot")
+            }
+
             // Thumbnail
             Group {
                 if let thumbnail {
@@ -145,6 +251,16 @@ private struct SettingsHistoryItemRow: View {
                         .font(.system(size: 18))
                         .foregroundStyle(.white.opacity(0.9), .black.opacity(0.35))
                         .shadow(color: .black.opacity(0.2), radius: 3, x: 0, y: 1)
+                }
+            }
+            .overlay(alignment: .bottomTrailing) {
+                if isInBasket {
+                    Image(systemName: "basket.fill")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(4)
+                        .background(.blue, in: Circle())
+                        .offset(x: 4, y: 4)
                 }
             }
 
@@ -217,6 +333,13 @@ private struct SettingsHistoryItemRow: View {
             isHovering = hovering
         }
         .contextMenu {
+            if !item.isVideo {
+                Button(isInBasket ? "Remove from Basket" : "Add to Basket", systemImage: "basket") {
+                    onToggleBasket()
+                }
+                Divider()
+            }
+
             Button("Quick Look", systemImage: "eye") { onPreview() }
             Button("Copy", systemImage: "doc.on.doc") { onCopy() }
             Button(item.isVideo ? "Edit Recording" : "Annotate", systemImage: item.isVideo ? "scissors" : "pencil.tip.crop.circle") { onEdit() }


### PR DESCRIPTION
## Summary

- Add a shared basket for grouping screenshots from recent captures or History
- Support Shift-click range selection and Cmd+A select all in History
- Remove the extra Select All button while keeping the Add to Basket action
- Drag the basket as a native multi-file payload into compatible apps
- Add review, remove, clear, and Copy All actions
- Keep the basket session-scoped and remove missing temporary files automatically

## Demo

https://github.com/user-attachments/assets/91f1c138-ef84-48cf-b08f-0099276f1d33

## Testing

- Unsigned Debug build completed successfully with the Screendrop scheme
- Verified native multi-file drag payload and basket actions locally
- Rebuilt successfully after adding History selection shortcuts