### PR TITLE
Add Capture Text (OCR area capture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A beautiful screenshot + screen recording + Loom alternative - all native, self 
 - Capture a display, window, or selected area as a screenshot or recording.
 - Configure global hotkeys, timers, file formats, save behavior, and complete after-capture workflows.
 - Copy, compress, save, pin, preview, annotate, edit, upload, or delete directly from a customizable floating preview stack.
+- Grab text off the screen with on-device OCR - no screenshot saved, just the text on your clipboard.
 - Open images from Finder with Screendrop and edit imported copies without touching the originals.
 - Annotate non-destructively with drawing tools, crop, smart redaction, backgrounds, wallpaper packs, perspective effects, progressive blur, borders, and watermarks.
 - Record camera, microphone, and system audio as separately editable sources.
@@ -82,8 +83,9 @@ Screendrop can be controlled from its menu bar item or with global hotkeys.
 | `Option + 2` | Capture a window |
 | `Option + 3` | Capture an area |
 | `Option + 4` | Open the screen-recording picker |
+| `Option + 5` | Capture text (OCR) to the clipboard |
 
-All four shortcuts are customizable under **Settings → Screenshots** and **Settings → Screen Recordings**.
+All five shortcuts are customizable under **Settings → Screenshots** and **Settings → Screen Recordings**.
 
 You can also:
 
@@ -106,6 +108,17 @@ Screenshot preferences include:
 - A configurable export folder and a Save action that can bypass the save panel.
 - A lower-resolution editor preview to reduce memory use while preserving full-resolution exports.
 - An option to include Screendrop's own windows in screenshots and recordings; they are excluded by default.
+
+### Capture Text
+
+**Capture Text** (`Option + 5`, or the menu bar) drags out an area like a normal
+area capture, recognizes the text inside it with on-device Vision OCR, and puts
+that text on the clipboard. No image is saved, nothing is added to History, and
+no preview card appears - a brief toast confirms what was copied.
+
+Recognized lines are returned in reading order, so multi-column screenshots
+paste in the order you read them rather than the order Vision happened to find
+them.
 
 ### After-Capture Automation
 

--- a/Screendrop/CaptureCoordinator.swift
+++ b/Screendrop/CaptureCoordinator.swift
@@ -9,6 +9,15 @@ import AppKit
 import ScreenCaptureKit
 import SwiftUI
 
+/// What a Capture Text run produced. `cancelled` and `noTextFound` look the
+/// same to a caller handed a plain optional, but a Shortcut needs to tell the
+/// user which one happened.
+enum CaptureTextOutcome {
+    case cancelled
+    case noTextFound
+    case copied(String)
+}
+
 /// Single long-lived coordinator that manages the capture → preview flow.
 @Observable
 final class CaptureCoordinator {
@@ -62,6 +71,16 @@ final class CaptureCoordinator {
         await performCaptureArea()
     }
 
+    /// Returns the recognized text rather than a URL - Capture Text produces
+    /// no file, and a Shortcuts action that hands back a string is what makes
+    /// it composable with the rest of a workflow. The outcome distinguishes a
+    /// cancelled selection from a region that simply had no text in it, which
+    /// a Shortcut needs to report accurately.
+    @discardableResult
+    func captureTextAwaiting() async -> CaptureTextOutcome {
+        await performCaptureText()
+    }
+
     @discardableResult
     private func performCaptureFullscreen() async -> URL? {
         let displayID = ActiveDisplayResolver.activeDisplayID(preferPointer: false)
@@ -106,10 +125,11 @@ final class CaptureCoordinator {
     ///
     /// The self-timer is handled by screencapture's `-T`, so the delay happens
     /// after the area is drawn, matching Capture Area.
-    private func performCaptureText() async {
+    @discardableResult
+    private func performCaptureText() async -> CaptureTextOutcome {
         guard let url = await ScreenshotManager.shared.captureArea(
             delaySeconds: ScreendropPreferences.captureDelaySeconds
-        ) else { return }
+        ) else { return .cancelled }
         defer { try? FileManager.default.removeItem(at: url) }
 
         // Resolved before recognition runs, so the toast lands on the display
@@ -123,7 +143,7 @@ final class CaptureCoordinator {
             if ScreendropPreferences.playSounds {
                 NSSound.beep()
             }
-            return
+            return .noTextFound
         }
 
         NSPasteboard.general.clearContents()
@@ -132,6 +152,7 @@ final class CaptureCoordinator {
         if ScreendropPreferences.playSounds {
             CaptureFeedbackSound.play()
         }
+        return .copied(text)
     }
 
     func recordFullscreen(_ display: SCDisplay) {

--- a/Screendrop/CaptureCoordinator.swift
+++ b/Screendrop/CaptureCoordinator.swift
@@ -36,6 +36,10 @@ final class CaptureCoordinator {
         Task { await performCaptureArea() }
     }
 
+    func captureText() {
+        Task { await performCaptureText() }
+    }
+
     // MARK: - Awaitable Capture Actions
 
     /// Awaitable variants for callers (App Intents / Shortcuts) that need the
@@ -92,6 +96,24 @@ final class CaptureCoordinator {
         ) else { return nil }
         let displayID = ActiveDisplayResolver.activeDisplayID(preferPointer: true)
         return finishCapture(url: url, displayID: displayID)
+    }
+
+    private func performCaptureText() async {
+        guard let url = await ScreenshotManager.shared.captureArea(
+            delaySeconds: ScreendropPreferences.captureDelaySeconds
+        ) else { return }
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let text = await ImageTextRecognizer.recognizeText(at: url)
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            NSSound.beep()
+            return
+        }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        if ScreendropPreferences.playSounds {
+            CaptureFeedbackSound.play()
+        }
     }
 
     func recordFullscreen(_ display: SCDisplay) {

--- a/Screendrop/CaptureCoordinator.swift
+++ b/Screendrop/CaptureCoordinator.swift
@@ -98,19 +98,37 @@ final class CaptureCoordinator {
         return finishCapture(url: url, displayID: displayID)
     }
 
+    /// Capture Text is the odd one out: it recognizes the text inside the drawn
+    /// area, puts it on the clipboard, and throws the image away. It
+    /// deliberately skips `finishCapture` - there is no file to import into
+    /// history, no preview card to raise, and no after-capture action to run -
+    /// so the toast and the capture sound are its only feedback.
+    ///
+    /// The self-timer is handled by screencapture's `-T`, so the delay happens
+    /// after the area is drawn, matching Capture Area.
     private func performCaptureText() async {
         guard let url = await ScreenshotManager.shared.captureArea(
             delaySeconds: ScreendropPreferences.captureDelaySeconds
         ) else { return }
         defer { try? FileManager.default.removeItem(at: url) }
 
+        // Resolved before recognition runs, so the toast lands on the display
+        // the user was just drawing on rather than wherever the pointer
+        // drifted to while Vision worked.
+        let displayID = ActiveDisplayResolver.activeDisplayID(preferPointer: true)
         let text = await ImageTextRecognizer.recognizeText(at: url)
+
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            NSSound.beep()
+            CaptureTextFeedbackPresenter.shared.showNoTextFound(displayID: displayID)
+            if ScreendropPreferences.playSounds {
+                NSSound.beep()
+            }
             return
         }
+
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
+        CaptureTextFeedbackPresenter.shared.showCopied(text: text, displayID: displayID)
         if ScreendropPreferences.playSounds {
             CaptureFeedbackSound.play()
         }

--- a/Screendrop/CaptureHotkeys.swift
+++ b/Screendrop/CaptureHotkeys.swift
@@ -150,8 +150,8 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
     case fullscreen
     case window
     case area
-    case textCapture
     case screenRecording
+    case textCapture
 
     var id: Self { self }
 
@@ -160,8 +160,8 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
         case .fullscreen: 1
         case .window: 2
         case .area: 3
-        case .textCapture: 5
         case .screenRecording: 4
+        case .textCapture: 5
         }
     }
 
@@ -170,8 +170,8 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
         case .fullscreen: "Fullscreen"
         case .window: "Window"
         case .area: "Area"
-        case .textCapture: "Capture Text"
         case .screenRecording: "Screen Recording"
+        case .textCapture: "Capture Text"
         }
     }
 
@@ -183,10 +183,10 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
             HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_2))
         case .area:
             HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_3))
-        case .textCapture:
-            HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_5))
         case .screenRecording:
             HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_4))
+        case .textCapture:
+            HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_5))
         }
     }
 
@@ -198,10 +198,10 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
             ScreendropPreferences.windowHotkeyKey
         case .area:
             ScreendropPreferences.areaHotkeyKey
-        case .textCapture:
-            ScreendropPreferences.textCaptureHotkeyKey
         case .screenRecording:
             ScreendropPreferences.screenRecordingHotkeyKey
+        case .textCapture:
+            ScreendropPreferences.textCaptureHotkeyKey
         }
     }
 
@@ -221,12 +221,12 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
             CaptureCoordinator.shared.captureWindow()
         case .area:
             CaptureCoordinator.shared.captureArea()
-        case .textCapture:
-            CaptureCoordinator.shared.captureText()
         case .screenRecording:
             Task { @MainActor in
                 RecordingPickerPresenter.shared.toggle()
             }
+        case .textCapture:
+            CaptureCoordinator.shared.captureText()
         }
     }
 }

--- a/Screendrop/CaptureHotkeys.swift
+++ b/Screendrop/CaptureHotkeys.swift
@@ -150,6 +150,7 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
     case fullscreen
     case window
     case area
+    case textCapture
     case screenRecording
 
     var id: Self { self }
@@ -159,6 +160,7 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
         case .fullscreen: 1
         case .window: 2
         case .area: 3
+        case .textCapture: 5
         case .screenRecording: 4
         }
     }
@@ -168,6 +170,7 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
         case .fullscreen: "Fullscreen"
         case .window: "Window"
         case .area: "Area"
+        case .textCapture: "Capture Text"
         case .screenRecording: "Screen Recording"
         }
     }
@@ -180,6 +183,8 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
             HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_2))
         case .area:
             HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_3))
+        case .textCapture:
+            HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_5))
         case .screenRecording:
             HotkeyShortcut(modifiers: [.option], keyCode: Int(kVK_ANSI_4))
         }
@@ -193,6 +198,8 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
             ScreendropPreferences.windowHotkeyKey
         case .area:
             ScreendropPreferences.areaHotkeyKey
+        case .textCapture:
+            ScreendropPreferences.textCaptureHotkeyKey
         case .screenRecording:
             ScreendropPreferences.screenRecordingHotkeyKey
         }
@@ -214,6 +221,8 @@ enum CaptureHotkeyAction: String, CaseIterable, Identifiable {
             CaptureCoordinator.shared.captureWindow()
         case .area:
             CaptureCoordinator.shared.captureArea()
+        case .textCapture:
+            CaptureCoordinator.shared.captureText()
         case .screenRecording:
             Task { @MainActor in
                 RecordingPickerPresenter.shared.toggle()

--- a/Screendrop/CaptureTextFeedbackPresenter.swift
+++ b/Screendrop/CaptureTextFeedbackPresenter.swift
@@ -1,0 +1,189 @@
+//
+//  CaptureTextFeedbackPresenter.swift
+//  Screendrop
+//
+//  Capture Text is the one capture action that leaves nothing behind - no
+//  file, no history entry, no preview card - so the capture sound was its
+//  only signal that anything happened, and users with sounds turned off got
+//  no feedback at all. This is the missing surface: a brief centered toast
+//  that confirms what landed on the clipboard, or says nothing was found.
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+final class CaptureTextFeedbackPresenter {
+    static let shared = CaptureTextFeedbackPresenter()
+
+    private static let panelSize = NSSize(width: 300, height: 52)
+    /// Clears the bottom edge by more than the toast is tall, so it reads as
+    /// floating over the work rather than stuck to the screen edge.
+    private static let bottomInset: CGFloat = 96
+    private static let visibleDuration: Duration = .seconds(1.8)
+    private static let fadeOutDuration: TimeInterval = 0.2
+
+    private var panel: NSPanel?
+    private var dismissTask: Task<Void, Never>?
+
+    private init() {}
+
+    /// Confirms the copy, previewing the text itself so the user can tell at a
+    /// glance that the right region was read.
+    func showCopied(text: String, displayID: CGDirectDisplayID?) {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: true)
+        let title = lines.count == 1
+            ? "Copied 1 line"
+            : "Copied \(lines.count) lines"
+        present(
+            symbol: "text.viewfinder",
+            title: title,
+            detail: lines.first.map(String.init) ?? text,
+            displayID: displayID
+        )
+    }
+
+    /// The capture succeeded but Vision found nothing. Not a failure worth an
+    /// `NSAlert` - the user just picked an empty region and will try again.
+    func showNoTextFound(displayID: CGDirectDisplayID?) {
+        present(
+            symbol: "text.viewfinder",
+            title: "No text found",
+            detail: "Nothing was recognized in that area.",
+            displayID: displayID
+        )
+    }
+
+    private func present(
+        symbol: String,
+        title: String,
+        detail: String,
+        displayID: CGDirectDisplayID?
+    ) {
+        dismissTask?.cancel()
+        dismiss()
+
+        let size = Self.panelSize
+        let hostingView = NSHostingView(
+            rootView: CaptureTextFeedbackView(
+                symbol: symbol,
+                title: title,
+                detail: detail,
+                size: size
+            )
+        )
+        // The panel is framed by hand below, so the hosting view must not try
+        // to resize the window to its own intrinsic content size.
+        hostingView.sizingOptions = []
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.level = .statusBar
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+        panel.contentView = hostingView
+        panel.setFrame(
+            NSRect(origin: origin(size: size, displayID: displayID), size: size),
+            display: true
+        )
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+
+        // A back-to-back capture should not photograph the previous toast.
+        PreviewWindowCaptureExclusion.shared.register(window: panel)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.14
+            panel.animator().alphaValue = 1
+        }
+
+        self.panel = panel
+        dismissTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.visibleDuration)
+            guard !Task.isCancelled else { return }
+            await self?.fadeOutAndDismiss()
+        }
+    }
+
+    /// Awaits the fade rather than tearing down in an animation completion
+    /// handler, which would run outside this type's MainActor isolation.
+    private func fadeOutAndDismiss() async {
+        guard let panel else { return }
+
+        await NSAnimationContext.runAnimationGroup { context in
+            context.duration = Self.fadeOutDuration
+            panel.animator().alphaValue = 0
+        }
+
+        // A newer toast may have replaced this one mid-fade, in which case it
+        // has already ordered this panel out.
+        guard self.panel === panel else { return }
+        dismiss()
+    }
+
+    private func dismiss() {
+        panel?.orderOut(nil)
+        panel = nil
+    }
+
+    private func origin(size: NSSize, displayID: CGDirectDisplayID?) -> CGPoint {
+        let screen = screen(for: displayID) ?? NSScreen.main
+        guard let frame = screen?.visibleFrame else { return .zero }
+        return CGPoint(
+            x: frame.midX - size.width / 2,
+            y: frame.minY + Self.bottomInset
+        )
+    }
+
+    private func screen(for displayID: CGDirectDisplayID?) -> NSScreen? {
+        guard let displayID else { return nil }
+        return NSScreen.screens.first { screen in
+            (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == displayID
+        }
+    }
+}
+
+private struct CaptureTextFeedbackView: View {
+    let symbol: String
+    let title: String
+    let detail: String
+    let size: NSSize
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: symbol)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(.white)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.white)
+                Text(detail)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.65))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .frame(width: size.width, height: size.height)
+        .background {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.black.opacity(0.55))
+                .background(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(.ultraThinMaterial)
+                )
+        }
+    }
+}

--- a/Screendrop/ImageTextRecognizer.swift
+++ b/Screendrop/ImageTextRecognizer.swift
@@ -12,7 +12,8 @@ import Vision
 /// "Copy text from image" (OCR).
 enum ImageTextRecognizer {
     /// Recognises text in the image at `url`, returning the recognised lines
-    /// joined by newlines. Returns an empty string when nothing is found.
+    /// joined by newlines in reading order. Returns an empty string when
+    /// nothing is found.
     static func recognizeText(at url: URL) async -> String {
         await withCheckedContinuation { (continuation: CheckedContinuation<String, Never>) in
             DispatchQueue.global(qos: .userInitiated).async {
@@ -29,13 +30,54 @@ enum ImageTextRecognizer {
                 let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
                 do {
                     try handler.perform([request])
-                    let lines = (request.results as? [VNRecognizedTextObservation])?
-                        .compactMap { $0.topCandidates(1).first?.string } ?? []
+                    let observations = request.results ?? []
+                    let lines = readingOrder(observations)
+                        .compactMap { $0.topCandidates(1).first?.string }
                     continuation.resume(returning: lines.joined(separator: "\n"))
                 } catch {
                     continuation.resume(returning: "")
                 }
             }
         }
+    }
+
+    /// Vision returns observations in no documented order, which scrambles
+    /// anything laid out in columns. Groups them into visual lines top to
+    /// bottom, then orders each line left to right.
+    ///
+    /// Done as an explicit grouping pass rather than one clever comparator:
+    /// a tolerance-based comparator is not a strict weak ordering, and
+    /// `sorted(by:)` gives undefined results when handed one.
+    private static func readingOrder(
+        _ observations: [VNRecognizedTextObservation]
+    ) -> [VNRecognizedTextObservation] {
+        // Vision's normalized origin is bottom-left, so a larger midY sits
+        // higher on the page.
+        let topDown = observations.sorted { $0.boundingBox.midY > $1.boundingBox.midY }
+
+        var ordered: [VNRecognizedTextObservation] = []
+        var line: [VNRecognizedTextObservation] = []
+        var lineMidY: CGFloat = 0
+
+        func flushLine() {
+            ordered.append(contentsOf: line.sorted { $0.boundingBox.minX < $1.boundingBox.minX })
+            line.removeAll()
+        }
+
+        for observation in topDown {
+            let box = observation.boundingBox
+            // Two fragments belong to the same visual line when their centres
+            // sit within half a line height of each other.
+            if !line.isEmpty, abs(box.midY - lineMidY) > box.height / 2 {
+                flushLine()
+            }
+            if line.isEmpty {
+                lineMidY = box.midY
+            }
+            line.append(observation)
+        }
+        flushLine()
+
+        return ordered
     }
 }

--- a/Screendrop/MenuBarView.swift
+++ b/Screendrop/MenuBarView.swift
@@ -36,6 +36,12 @@ struct MenuBarView: View {
             }
 
             Button {
+                CaptureCoordinator.shared.captureText()
+            } label: {
+                Label("Capture Text", systemImage: "text.viewfinder")
+            }
+
+            Button {
                 RecordingPickerPresenter.shared.show()
             } label: {
                 Label("Record Screen", systemImage: "record.circle")

--- a/Screendrop/ScreendropAppIntents.swift
+++ b/Screendrop/ScreendropAppIntents.swift
@@ -22,6 +22,7 @@ import ScreenCaptureKit
 
 nonisolated enum ScreendropIntentError: Error, CustomLocalizedStringResourceConvertible {
     case captureCancelled
+    case noTextRecognized
     case recordingAlreadyActive
     case noActiveRecording
     case noDisplayAvailable
@@ -30,6 +31,8 @@ nonisolated enum ScreendropIntentError: Error, CustomLocalizedStringResourceConv
         switch self {
         case .captureCancelled:
             "The screenshot was cancelled before it could be captured."
+        case .noTextRecognized:
+            "No text was recognized in the captured area."
         case .recordingAlreadyActive:
             "Screendrop is already recording."
         case .noActiveRecording:
@@ -84,6 +87,25 @@ nonisolated struct TakeAreaScreenshotIntent: AppIntent {
             throw ScreendropIntentError.captureCancelled
         }
         return .result(value: IntentFile(fileURL: url))
+    }
+}
+
+nonisolated struct CaptureTextIntent: AppIntent {
+    static var title: LocalizedStringResource = "Capture Text"
+    static var description = IntentDescription(
+        "Recognizes the text inside a region you drag out, copies it to the clipboard, and returns it."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        switch await CaptureCoordinator.shared.captureTextAwaiting() {
+        case .cancelled:
+            throw ScreendropIntentError.captureCancelled
+        case .noTextFound:
+            throw ScreendropIntentError.noTextRecognized
+        case .copied(let text):
+            return .result(value: text)
+        }
     }
 }
 
@@ -181,6 +203,15 @@ nonisolated struct ScreendropShortcuts: AppShortcutsProvider {
             ],
             shortTitle: "Take Area Screenshot",
             systemImageName: "crop"
+        )
+        AppShortcut(
+            intent: CaptureTextIntent(),
+            phrases: [
+                "Capture text with \(.applicationName)",
+                "Copy text from the screen with \(.applicationName)"
+            ],
+            shortTitle: "Capture Text",
+            systemImageName: "text.viewfinder"
         )
         AppShortcut(
             intent: StartScreenRecordingIntent(),

--- a/Screendrop/ScreendropPreferences.swift
+++ b/Screendrop/ScreendropPreferences.swift
@@ -20,6 +20,7 @@ enum ScreendropPreferences {
     static let fullscreenHotkeyKey = "captureHotkey.fullscreen"
     static let windowHotkeyKey = "captureHotkey.window"
     static let areaHotkeyKey = "captureHotkey.area"
+    static let textCaptureHotkeyKey = "captureHotkey.textCapture"
     static let screenRecordingHotkeyKey = "captureHotkey.screenRecording"
     static let playSoundsKey = "playSounds"
     static let showMenuBarIconKey = "showMenuBarIcon"

--- a/Screendrop/SettingsScreenshotsPane.swift
+++ b/Screendrop/SettingsScreenshotsPane.swift
@@ -28,7 +28,7 @@ struct ScreenshotsSettingsPane: View {
 
     var body: some View {
         Form {
-            CaptureHotkeySettingsSection(actions: [.fullscreen, .window, .area])
+            CaptureHotkeySettingsSection(actions: [.fullscreen, .window, .area, .textCapture])
 
             Section("Capture") {
                 Picker(selection: $captureDelaySeconds) {


### PR DESCRIPTION
## Summary

  Adds a "Capture Text" action: draw an area on screen and the text inside it is recognized and copied to the
  clipboard. No screenshot is saved, no preview card is shown.

  Available from:
  - the menu bar (**Capture Text**, below Capture Area)
  - a global hotkey, default **⌥5**, rebindable in Settings → Screenshots

  ## How it works

  - Reuses the native `screencapture -i` area selector already used by Capture Area (including the capture delay
  preference).
  - Runs the existing Vision-based `ImageTextRecognizer` (already used by "Copy Text from Image") on the temp
  capture, copies the result to the pasteboard, then deletes the temp file.
  - Plays the capture sound on success (respects the sounds preference); beeps if no text was recognized.

## Preview 
<img width="264" height="298" alt="image" src="https://github.com/user-attachments/assets/1d802693-79e1-4770-aaf9-009a7108fad8" />
<img width="660" height="592" alt="image" src="https://github.com/user-attachments/assets/a32896da-e2bd-48e4-89da-5892677b4cdc" />

