### PR TITLE
Add screenshot preset sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Crop at full resolution with freeform, original, `1:1`, `16:9`, `9:16`, `4:3`, a
 Turn a plain screenshot into a finished visual without leaving Screendrop:
 
 - Apply solid colors, gradients, custom images, or downloadable wallpaper packs.
-- Save and reuse background presets.
+- Save, import, export, and share background presets as versioned `.screendroppreset` JSON files.
 - Adjust padding, corner radius, shadow, aspect ratio, and nine-point alignment.
 - Add a configurable solid border around the screenshot.
 - Add a text watermark with placement and typography controls.
@@ -191,6 +191,8 @@ Turn a plain screenshot into a finished visual without leaving Screendrop:
 - Add radial or directional progressive blur, either clipped to the screenshot or bleeding into the surrounding scene.
 
 The editor keeps these effects live and re-editable instead of flattening them into the source.
+
+Shared presets include portable colors, gradients, layout, camera, blur, border, and watermark settings. Local wallpaper images and their file paths are never exported or imported; a wallpaper-based preset uses no background when opened on another Mac.
 
 ## Screen Recording
 

--- a/Screendrop/AnnotationBackgroundPresetBar.swift
+++ b/Screendrop/AnnotationBackgroundPresetBar.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct AnnotationBackgroundPresetBar: View {
     @Bindable var model: AnnotationEditorModel
@@ -14,6 +15,7 @@ struct AnnotationBackgroundPresetBar: View {
     @State private var isNameEditorPresented = false
     @State private var draftName = ""
     @State private var presetPendingDeletion: AnnotationBackgroundPreset?
+    @State private var transferAlert: PresetTransferAlert?
     @FocusState private var isNameFieldFocused: Bool
 
     private var appliedPreset: AnnotationBackgroundPreset? {
@@ -101,6 +103,13 @@ struct AnnotationBackgroundPresetBar: View {
         } message: { preset in
             Text("“\(preset.name)” will be removed from your saved presets. The current canvas settings won’t change.")
         }
+        .alert(item: $transferAlert) { alert in
+            Alert(
+                title: Text(alert.title),
+                message: Text(alert.message),
+                dismissButton: .default(Text("OK"))
+            )
+        }
     }
 
     private var presetMenu: some View {
@@ -117,7 +126,9 @@ struct AnnotationBackgroundPresetBar: View {
                 guard let preset = presetStore.preset(id: presetID) else { return }
                 onEditorAction()
                 presetPendingDeletion = preset
-            }
+            },
+            onImportPreset: importPresets,
+            onExportPreset: exportPreset
         )
         .frame(maxWidth: .infinity, minHeight: 28, maxHeight: 28)
         .help(presetHelp)
@@ -233,6 +244,141 @@ struct AnnotationBackgroundPresetBar: View {
         presetStore.setActivePreset(id: preset.id)
         isNameEditorPresented = false
     }
+
+    private func importPresets() {
+        onEditorAction()
+
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.screendropPreset]
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.title = "Import Screenshot Presets"
+        panel.prompt = "Import"
+
+        panel.begin { response in
+            guard response == .OK else { return }
+            let urls = panel.urls
+
+            Task { @MainActor in
+                var importedPresets: [AnnotationBackgroundPreset] = []
+                var omittedWallpaperCount = 0
+                var failures: [String] = []
+
+                for url in urls {
+                    do {
+                        let transferFile = try AnnotationBackgroundPresetTransferFile.load(from: url)
+                        let result = try presetStore.importTransferFile(transferFile)
+                        importedPresets.append(contentsOf: result.importedPresets)
+                        omittedWallpaperCount += result.omittedWallpaperCount
+                    } catch {
+                        failures.append("\(url.lastPathComponent): \(error.localizedDescription)")
+                    }
+                }
+
+                if let firstImportedPreset = importedPresets.first {
+                    withAnimation(.snappy(duration: 0.2)) {
+                        model.applyBackgroundPreset(firstImportedPreset)
+                    }
+                }
+
+                transferAlert = Self.importAlert(
+                    importedCount: importedPresets.count,
+                    omittedWallpaperCount: omittedWallpaperCount,
+                    failures: failures
+                )
+            }
+        }
+    }
+
+    private func exportPreset(_ presetID: AnnotationBackgroundPreset.ID) {
+        onEditorAction()
+
+        do {
+            let transferFile = try presetStore.transferFile(for: presetID)
+            guard let preset = presetStore.preset(id: presetID) else {
+                throw AnnotationBackgroundPresetTransferError.presetNotFound
+            }
+
+            let panel = NSSavePanel()
+            panel.allowedContentTypes = [.screendropPreset]
+            panel.canCreateDirectories = true
+            panel.isExtensionHidden = false
+            panel.title = "Export Screenshot Preset"
+            panel.prompt = "Export"
+            panel.nameFieldStringValue = "\(Self.safeFilename(for: preset.name)).\(AnnotationBackgroundPresetTransferFile.filenameExtension)"
+
+            panel.begin { response in
+                guard response == .OK, let url = panel.url else { return }
+
+                Task { @MainActor in
+                    do {
+                        let data = try transferFile.encodedData()
+                        try data.write(to: url, options: .atomic)
+                        let omittedWallpaper = transferFile.presets.first?.omitted.contains(.wallpaper) == true
+                        transferAlert = PresetTransferAlert(
+                            title: "Preset Exported",
+                            message: omittedWallpaper
+                                ? "The local wallpaper was not included. The imported preset will use no background."
+                                : "“\(preset.name)” is ready to share."
+                        )
+                    } catch {
+                        transferAlert = PresetTransferAlert(
+                            title: "Export Failed",
+                            message: error.localizedDescription
+                        )
+                    }
+                }
+            }
+        } catch {
+            transferAlert = PresetTransferAlert(
+                title: "Export Failed",
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    private static func importAlert(
+        importedCount: Int,
+        omittedWallpaperCount: Int,
+        failures: [String]
+    ) -> PresetTransferAlert {
+        guard importedCount > 0 else {
+            return PresetTransferAlert(
+                title: "Import Failed",
+                message: failures.joined(separator: "\n")
+            )
+        }
+
+        let presetNoun = importedCount == 1 ? "preset" : "presets"
+        var messages = ["Imported \(importedCount) \(presetNoun)."]
+        if omittedWallpaperCount > 0 {
+            let wallpaperNoun = omittedWallpaperCount == 1 ? "wallpaper was" : "wallpapers were"
+            messages.append(
+                "\(omittedWallpaperCount) local \(wallpaperNoun) not included and will use no background."
+            )
+        }
+        if !failures.isEmpty {
+            messages.append("Some files could not be imported:\n\(failures.joined(separator: "\n"))")
+        }
+        return PresetTransferAlert(
+            title: importedCount == 1 ? "Preset Imported" : "Presets Imported",
+            message: messages.joined(separator: "\n\n")
+        )
+    }
+
+    private static func safeFilename(for presetName: String) -> String {
+        let forbiddenCharacters = CharacterSet(charactersIn: "/:\n\r")
+        let components = presetName.components(separatedBy: forbiddenCharacters)
+        let sanitized = components.filter { !$0.isEmpty }.joined(separator: "-")
+        return sanitized.isEmpty ? "Screenshot Preset" : sanitized
+    }
+}
+
+private struct PresetTransferAlert: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
 }
 
 private struct AnnotationPresetPopUpButton: NSViewRepresentable {
@@ -245,6 +391,8 @@ private struct AnnotationPresetPopUpButton: NSViewRepresentable {
     let onSelectPreset: (AnnotationBackgroundPreset.ID?) -> Void
     let onSetDefaultPreset: (AnnotationBackgroundPreset.ID?) -> Void
     let onDeletePreset: (AnnotationBackgroundPreset.ID) -> Void
+    let onImportPreset: () -> Void
+    let onExportPreset: (AnnotationBackgroundPreset.ID) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
@@ -301,7 +449,6 @@ private struct AnnotationPresetPopUpButton: NSViewRepresentable {
                 let emptyItem = NSMenuItem(title: "No Saved Presets", action: nil, keyEquivalent: "")
                 emptyItem.isEnabled = false
                 menu.addItem(emptyItem)
-                return menu
             }
 
             if !availablePresets.isEmpty {
@@ -352,6 +499,46 @@ private struct AnnotationPresetPopUpButton: NSViewRepresentable {
                 menu.addItem(defaultItem)
             }
 
+            menu.addItem(.separator())
+
+            let importItem = NSMenuItem(
+                title: "Import Preset…",
+                action: #selector(importPreset(_:)),
+                keyEquivalent: ""
+            )
+            importItem.target = self
+            importItem.image = NSImage(
+                systemSymbolName: "square.and.arrow.down",
+                accessibilityDescription: nil
+            )
+            menu.addItem(importItem)
+
+            if !parent.presets.isEmpty {
+                let exportItem = NSMenuItem(title: "Export Preset", action: nil, keyEquivalent: "")
+                exportItem.image = NSImage(
+                    systemSymbolName: "square.and.arrow.up",
+                    accessibilityDescription: nil
+                )
+                exportItem.submenu = makeExportMenu(presets: parent.presets)
+                menu.addItem(exportItem)
+            }
+
+            return menu
+        }
+
+        private func makeExportMenu(presets: [AnnotationBackgroundPreset]) -> NSMenu {
+            let menu = NSMenu(title: "Export Preset")
+            menu.autoenablesItems = false
+
+            for preset in presets {
+                menu.addItem(
+                    presetItem(
+                        preset,
+                        action: #selector(exportPreset(_:)),
+                        isSelected: false
+                    )
+                )
+            }
             return menu
         }
 
@@ -418,6 +605,15 @@ private struct AnnotationPresetPopUpButton: NSViewRepresentable {
         @objc private func deletePreset(_ sender: NSMenuItem) {
             guard let presetID = presetID(from: sender) else { return }
             parent.onDeletePreset(presetID)
+        }
+
+        @objc private func importPreset(_ sender: NSMenuItem) {
+            parent.onImportPreset()
+        }
+
+        @objc private func exportPreset(_ sender: NSMenuItem) {
+            guard let presetID = presetID(from: sender) else { return }
+            parent.onExportPreset(presetID)
         }
     }
 }

--- a/Screendrop/AnnotationBackgroundPresetStore.swift
+++ b/Screendrop/AnnotationBackgroundPresetStore.swift
@@ -48,6 +48,11 @@ struct AnnotationBackgroundPreset: Identifiable, Codable, Equatable {
     }
 }
 
+struct AnnotationBackgroundPresetImportResult {
+    var importedPresets: [AnnotationBackgroundPreset]
+    var omittedWallpaperCount: Int
+}
+
 extension AnnotationBackgroundSettings {
     fileprivate var presetComparable: AnnotationBackgroundSettings {
         var comparable = self
@@ -171,6 +176,51 @@ final class AnnotationBackgroundPresetStore {
         }
         activePresetID = id
         persist()
+    }
+
+    func transferFile(
+        for id: AnnotationBackgroundPreset.ID
+    ) throws -> AnnotationBackgroundPresetTransferFile {
+        guard let preset = preset(id: id) else {
+            throw AnnotationBackgroundPresetTransferError.presetNotFound
+        }
+        return AnnotationBackgroundPresetTransferFile(preset: preset)
+    }
+
+    /// Imports portable presets with fresh local identities. Imported presets
+    /// never replace an existing preset or become the default automatically.
+    @discardableResult
+    func importTransferFile(
+        _ transferFile: AnnotationBackgroundPresetTransferFile
+    ) throws -> AnnotationBackgroundPresetImportResult {
+        let transferPresets = try transferFile.validatedPresets()
+        var importedPresets: [AnnotationBackgroundPreset] = []
+        var omittedWallpaperCount = 0
+
+        for transferPreset in transferPresets {
+            let normalized = Self.normalizedName(transferPreset.name)
+            let baseName = normalized.isEmpty ? "Untitled Preset" : normalized
+            let name = Self.uniqueSanitizedName(
+                baseName,
+                existingNames: presets.map(\.name) + importedPresets.map(\.name)
+            )
+            let preset = AnnotationBackgroundPreset(
+                name: name,
+                settings: transferPreset.settings.annotationSettings
+            )
+            importedPresets.append(preset)
+
+            if transferPreset.omitted.contains(.wallpaper) {
+                omittedWallpaperCount += 1
+            }
+        }
+
+        presets.append(contentsOf: importedPresets)
+        persist()
+        return AnnotationBackgroundPresetImportResult(
+            importedPresets: importedPresets,
+            omittedWallpaperCount: omittedWallpaperCount
+        )
     }
 
     @discardableResult

--- a/Screendrop/AnnotationBackgroundPresetTransfer.swift
+++ b/Screendrop/AnnotationBackgroundPresetTransfer.swift
@@ -1,0 +1,342 @@
+//
+//  AnnotationBackgroundPresetTransfer.swift
+//  Screendrop
+//
+
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension UTType {
+    static let screendropPreset = UTType(
+        exportedAs: "com.fayazahmed.screendrop.preset",
+        conformingTo: .json
+    )
+}
+
+/// A portable, versioned preset document. This deliberately does not reuse
+/// `StoredBackground`: that persistence model contains local wallpaper paths,
+/// while a shared preset must not be able to represent a path or image asset.
+struct AnnotationBackgroundPresetTransferFile: Codable {
+    static let currentVersion = 1
+    static let formatIdentifier = "screendrop-screenshot-presets"
+    static let filenameExtension = "screendroppreset"
+    static let maximumFileSize = 1_000_000
+    static let maximumPresetCount = 100
+
+    var format: String
+    var version: Int
+    var presets: [Preset]
+
+    init(preset: AnnotationBackgroundPreset) {
+        let portableSettings = PortableBackgroundSettings(preset.settings)
+        format = Self.formatIdentifier
+        version = Self.currentVersion
+        presets = [
+            Preset(
+                name: preset.name,
+                settings: portableSettings,
+                omitted: portableSettings.didOmitWallpaper ? [.wallpaper] : []
+            )
+        ]
+    }
+
+    func encodedData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(self)
+    }
+
+    static func load(from url: URL) throws -> AnnotationBackgroundPresetTransferFile {
+        let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+        guard fileSize <= maximumFileSize else {
+            throw AnnotationBackgroundPresetTransferError.fileTooLarge
+        }
+
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        guard data.count <= maximumFileSize else {
+            throw AnnotationBackgroundPresetTransferError.fileTooLarge
+        }
+
+        do {
+            return try JSONDecoder().decode(Self.self, from: data)
+        } catch {
+            throw AnnotationBackgroundPresetTransferError.invalidJSON
+        }
+    }
+
+    func validatedPresets() throws -> [Preset] {
+        guard format == Self.formatIdentifier else {
+            throw AnnotationBackgroundPresetTransferError.invalidFormat
+        }
+        guard version == Self.currentVersion else {
+            throw AnnotationBackgroundPresetTransferError.unsupportedVersion(version)
+        }
+        guard !presets.isEmpty else {
+            throw AnnotationBackgroundPresetTransferError.emptyFile
+        }
+        guard presets.count <= Self.maximumPresetCount else {
+            throw AnnotationBackgroundPresetTransferError.tooManyPresets
+        }
+        return presets
+    }
+
+    struct Preset: Codable {
+        var name: String
+        var settings: PortableBackgroundSettings
+        var omitted: [Omission]
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case settings
+            case omitted
+        }
+
+        init(
+            name: String,
+            settings: PortableBackgroundSettings,
+            omitted: [Omission]
+        ) {
+            self.name = name
+            self.settings = settings
+            self.omitted = omitted
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            settings = try container.decode(PortableBackgroundSettings.self, forKey: .settings)
+            omitted = try container.decodeIfPresent([Omission].self, forKey: .omitted) ?? []
+        }
+    }
+
+    enum Omission: String, Codable {
+        case wallpaper
+    }
+}
+
+struct PortableBackgroundSettings: Codable {
+    var style: PortableBackgroundStyle
+    var padding: Double
+    var cornerRadius: Double
+    var shadow: Double
+    var shadowStyle: String?
+    var aspectRatio: String
+    var alignment: String
+    var camera: StoredCameraSettings?
+    var progressiveBlur: StoredProgressiveBlurSettings?
+    var border: StoredScreenshotBorder?
+    var watermark: StoredWatermark?
+
+    private(set) var didOmitWallpaper = false
+
+    private enum CodingKeys: String, CodingKey {
+        case style
+        case padding
+        case cornerRadius
+        case shadow
+        case shadowStyle
+        case aspectRatio
+        case alignment
+        case camera
+        case progressiveBlur
+        case border
+        case watermark
+    }
+
+    init(_ settings: AnnotationBackgroundSettings) {
+        switch settings.style {
+        case .none:
+            style = .none
+        case .solid(let color):
+            style = .solid(StoredColor(color))
+        case .gradient(let gradient):
+            style = .gradient(StoredGradient(gradient))
+        case .customWallpaper:
+            style = .none
+            didOmitWallpaper = true
+        }
+
+        padding = Double(settings.padding)
+        cornerRadius = Double(settings.cornerRadius)
+        shadow = Double(settings.shadow)
+        shadowStyle = settings.shadowStyle.rawValue
+        aspectRatio = settings.aspectRatio.rawValue
+        alignment = settings.alignment.rawValue
+        camera = StoredCameraSettings(settings.camera)
+        progressiveBlur = StoredProgressiveBlurSettings(settings.progressiveBlur)
+        border = StoredScreenshotBorder(settings.border)
+        watermark = StoredWatermark(settings.watermark)
+    }
+
+    var annotationSettings: AnnotationBackgroundSettings {
+        var output = AnnotationBackgroundSettings()
+        switch style {
+        case .none:
+            output.style = .none
+        case .solid(let color):
+            output.style = .solid(Self.sanitizedColor(color))
+        case .gradient(let gradient):
+            output.style = .gradient(Self.sanitizedGradient(gradient))
+        }
+
+        output.padding = CGFloat(Self.clamp(padding, to: 0.04...0.45))
+        output.cornerRadius = CGFloat(Self.clamp(cornerRadius, to: 0...0.12))
+        output.shadow = CGFloat(Self.clamp(shadow, to: 0...1))
+        output.shadowStyle = shadowStyle.flatMap(AnnotationShadowStyle.init(rawValue:)) ?? .soft
+        output.aspectRatio = AnnotationBackgroundAspectRatio(rawValue: aspectRatio) ?? .auto
+        output.alignment = AnnotationBackgroundAlignment(rawValue: alignment) ?? .center
+        output.customWallpaper = nil
+
+        if var camera = camera?.settings {
+            camera.panX = CGFloat(Self.clamp(Double(camera.panX), to: -0.5...0.5))
+            camera.panY = CGFloat(Self.clamp(Double(camera.panY), to: -0.5...0.5))
+            camera.tiltXDegrees = CGFloat(Self.clamp(Double(camera.tiltXDegrees), to: -45...45))
+            camera.tiltYDegrees = CGFloat(Self.clamp(Double(camera.tiltYDegrees), to: -45...45))
+            camera.rotationXDegrees = CGFloat(Self.clamp(Double(camera.rotationXDegrees), to: -60...60))
+            camera.rotationYDegrees = CGFloat(Self.clamp(Double(camera.rotationYDegrees), to: -60...60))
+            camera.rollDegrees = CGFloat(Self.clamp(Double(camera.rollDegrees), to: -45...45))
+            camera.fieldOfViewDegrees = CGFloat(Self.clamp(Double(camera.fieldOfViewDegrees), to: 18...80))
+            camera.zoom = CGFloat(Self.clamp(Double(camera.zoom), to: 0.4...2.5))
+            output.camera = camera
+        }
+
+        if var blur = progressiveBlur?.settings {
+            blur.strength = CGFloat(Self.clamp(Double(blur.strength), to: 0...40))
+            blur.falloff = CGFloat(Self.clamp(Double(blur.falloff), to: 0...1))
+            blur.focusSize = CGFloat(Self.clamp(Double(blur.focusSize), to: 0...1))
+            blur.focusPosition.x = CGFloat(Self.clamp(Double(blur.focusPosition.x), to: 0...1))
+            blur.focusPosition.y = CGFloat(Self.clamp(Double(blur.focusPosition.y), to: 0...1))
+            blur.directionDegrees = CGFloat(Self.clamp(Double(blur.directionDegrees), to: 0...180))
+            output.progressiveBlur = blur
+        }
+
+        if var border = border?.settings {
+            border.thickness = CGFloat(Self.clamp(Double(border.thickness), to: 0.002...0.08))
+            border.opacity = CGFloat(Self.clamp(Double(border.opacity), to: 0...1))
+            output.border = border
+        }
+
+        if var watermark = watermark?.settings {
+            watermark.text = String(watermark.text.prefix(500))
+            watermark.density = CGFloat(Self.clamp(Double(watermark.density), to: 2...10))
+            watermark.fontSize = CGFloat(Self.clamp(Double(watermark.fontSize), to: 8...160))
+            watermark.rotationDegrees = CGFloat(Self.clamp(Double(watermark.rotationDegrees), to: -90...90))
+            watermark.opacity = CGFloat(Self.clamp(Double(watermark.opacity), to: 0...0.75))
+            watermark.color = AnnotationWatermarkColor(
+                red: CGFloat(Self.clamp(Double(watermark.color.red), to: 0...1)),
+                green: CGFloat(Self.clamp(Double(watermark.color.green), to: 0...1)),
+                blue: CGFloat(Self.clamp(Double(watermark.color.blue), to: 0...1)),
+                alpha: CGFloat(Self.clamp(Double(watermark.color.alpha), to: 0...1))
+            )
+            output.watermark = watermark
+        }
+
+        return output
+    }
+
+    private static func sanitizedColor(_ color: StoredColor) -> AnnotationBackgroundColor {
+        AnnotationBackgroundColor(
+            String(color.id.prefix(100)),
+            title: String(color.title.prefix(100)),
+            red: CGFloat(clamp(color.red, to: 0...1)),
+            green: CGFloat(clamp(color.green, to: 0...1)),
+            blue: CGFloat(clamp(color.blue, to: 0...1)),
+            alpha: CGFloat(clamp(color.alpha, to: 0...1))
+        )
+    }
+
+    private static func sanitizedGradient(_ gradient: StoredGradient) -> AnnotationBackgroundGradient {
+        let colors = gradient.colors.prefix(8).map(sanitizedColor)
+        return AnnotationBackgroundGradient(
+            id: String(gradient.id.prefix(100)),
+            title: String(gradient.title.prefix(100)),
+            colors: colors.isEmpty ? [.graphite] : colors,
+            startPoint: UnitPoint(
+                x: CGFloat(clamp(gradient.startX, to: 0...1)),
+                y: CGFloat(clamp(gradient.startY, to: 0...1))
+            ),
+            endPoint: UnitPoint(
+                x: CGFloat(clamp(gradient.endX, to: 0...1)),
+                y: CGFloat(clamp(gradient.endY, to: 0...1))
+            )
+        )
+    }
+
+    private static func clamp(_ value: Double, to range: ClosedRange<Double>) -> Double {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+}
+
+enum PortableBackgroundStyle: Codable {
+    case none
+    case solid(StoredColor)
+    case gradient(StoredGradient)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case color
+        case gradient
+    }
+
+    private enum StyleType: String, Codable {
+        case none
+        case solid
+        case gradient
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(StyleType.self, forKey: .type) {
+        case .none:
+            self = .none
+        case .solid:
+            self = .solid(try container.decode(StoredColor.self, forKey: .color))
+        case .gradient:
+            self = .gradient(try container.decode(StoredGradient.self, forKey: .gradient))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .none:
+            try container.encode(StyleType.none, forKey: .type)
+        case .solid(let color):
+            try container.encode(StyleType.solid, forKey: .type)
+            try container.encode(color, forKey: .color)
+        case .gradient(let gradient):
+            try container.encode(StyleType.gradient, forKey: .type)
+            try container.encode(gradient, forKey: .gradient)
+        }
+    }
+}
+
+enum AnnotationBackgroundPresetTransferError: LocalizedError {
+    case presetNotFound
+    case invalidJSON
+    case invalidFormat
+    case unsupportedVersion(Int)
+    case emptyFile
+    case tooManyPresets
+    case fileTooLarge
+
+    var errorDescription: String? {
+        switch self {
+        case .presetNotFound:
+            "The selected preset no longer exists."
+        case .invalidJSON:
+            "This is not a valid Screendrop preset file."
+        case .invalidFormat:
+            "This JSON file is not a Screendrop screenshot preset."
+        case .unsupportedVersion(let version):
+            "This preset uses unsupported format version \(version)."
+        case .emptyFile:
+            "This preset file does not contain any presets."
+        case .tooManyPresets:
+            "This preset file contains too many presets."
+        case .fileTooLarge:
+            "This preset file is larger than 1 MB."
+        }
+    }
+}

--- a/Screendrop/Info.plist
+++ b/Screendrop/Info.plist
@@ -33,5 +33,27 @@
 	<string>https://raw.githubusercontent.com/fayazara/screendrop/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>MA/6n0fqT0T2updDlkXr8BjhJKoHWik9uf6Lh5pUG7U=</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Screendrop Screenshot Preset</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.fayazahmed.screendrop.preset</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>screendroppreset</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/vnd.screendrop.preset+json</string>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add versioned .screendroppreset JSON import and export from the screenshot preset menu
- keep wallpaper images and local file paths out of shared presets, falling back to no background with clear feedback
- validate imports, generate fresh IDs, suffix duplicate names, and preserve local default selection
- register the custom file type and document the workflow

## Verification
- Screendrop Debug build: BUILD SUCCEEDED
- Info.plist validation passed
- git diff --check passed

Runtime UI testing was not performed.