### PR TITLE
Add keyboard opacity controls for pinned screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ New captures appear as floating cards on the active display. From a card you can
 - Delete the file or dismiss only the preview.
 - Copy recognized text from a screenshot using on-device OCR.
 
+Click a pinned screenshot and press `1`–`9` to set its opacity from 10%–90%, or press `0` to restore 100% opacity. These number-key controls are scoped to the focused pinned screenshot.
+
 The overlay can appear on the left or right, close automatically after a chosen delay, and dismiss after a drag. Its actions are completely rearrangeable: drag actions between four corner slots, the center buttons, and a hidden-actions tray in **Settings → Overlay**.
 
 When the stack is collapsed, it becomes a small peek tab instead of disappearing. This keeps captures close without covering the workspace.

--- a/Screendrop/PinnedScreenshotPresenter.swift
+++ b/Screendrop/PinnedScreenshotPresenter.swift
@@ -33,6 +33,7 @@ final class PinnedScreenshotPresenter {
         panel.hasShadow = true
         panel.level = .floating
         panel.isFloatingPanel = true
+        panel.becomesKeyOnlyIfNeeded = false
         panel.isMovableByWindowBackground = true
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
@@ -92,6 +93,36 @@ final class PinnedScreenshotPresenter {
 private final class PinnedPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    override func sendEvent(_ event: NSEvent) {
+        // Borderless non-activating panels do not reliably take key focus when
+        // their background is clicked. Explicitly focus the pin so subsequent
+        // number keys are delivered here without activating Screendrop.
+        if event.type == .leftMouseDown || event.type == .rightMouseDown {
+            makeKey()
+        }
+
+        if event.type == .keyDown, let opacity = Self.opacity(for: event) {
+            alphaValue = opacity
+            return
+        }
+
+        super.sendEvent(event)
+    }
+
+    /// Plain number keys set the opacity of the focused pin: 1 is 10%,
+    /// through 9 at 90%, while 0 restores full opacity.
+    private static func opacity(for event: NSEvent) -> CGFloat? {
+        let disallowedModifiers: NSEvent.ModifierFlags = [.command, .control, .option, .shift]
+        guard event.modifierFlags.intersection(disallowedModifiers).isEmpty,
+              let character = event.charactersIgnoringModifiers?.first,
+              let digit = character.wholeNumberValue,
+              (0...9).contains(digit) else {
+            return nil
+        }
+
+        return digit == 0 ? 1 : CGFloat(digit) / 10
+    }
 }
 
 private struct PinnedScreenshotView: View {


### PR DESCRIPTION
## Summary

- let focused pinned screenshots handle plain number keys
- map `1`–`9` to 10%–90% opacity and `0` to 100%
- explicitly focus clicked non-activating pin panels so shortcuts are scoped to the intended screenshot
- document the controls in the README

## Testing

- `xcodebuild -project Screendrop.xcodeproj -scheme Screendrop -configuration Debug -derivedDataPath /tmp/screendrop-derived CODE_SIGNING_ALLOWED=NO build`
- signed Debug Dev build launched successfully on macOS