### PR TITLE
Add Ctrl+V preview dismissal

### DIFF
--- a/Screendrop/PreviewWindowView.swift
+++ b/Screendrop/PreviewWindowView.swift
@@ -316,7 +316,9 @@ struct PreviewWindowView: View {
         }
         
         globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
-            if previewStack.hoveredItemID != nil || QuickLookPreviewPresenter.isShown {
+            if previewStack.isPasteDismissalReady
+                || previewStack.hoveredItemID != nil
+                || QuickLookPreviewPresenter.isShown {
                 _ = handlePreviewKey(event)
             }
         }
@@ -398,6 +400,14 @@ struct PreviewWindowView: View {
     private func handlePreviewKey(_ event: NSEvent) -> Bool {
         guard !previewStack.isExiting else { return false }
 
+        // This is an observation-only shortcut: keep the Ctrl+V event flowing
+        // to the destination app while closing the preview once its copied
+        // image is actually being pasted.
+        if isPasteShortcut(event), previewStack.isPasteDismissalReady {
+            previewStack.dismissAll()
+            return false
+        }
+
         if event.keyCode == 53, QuickLookPreviewPresenter.isShown {
             QuickLookPreviewPresenter.dismiss()
             return true
@@ -410,5 +420,13 @@ struct PreviewWindowView: View {
         }
         
         return false
+    }
+
+    /// Recognizes Ctrl+V for the prototype paste-to-dismiss behavior, without
+    /// treating Command-V or modified variants as a paste confirmation.
+    private func isPasteShortcut(_ event: NSEvent) -> Bool {
+        event.modifierFlags.contains(.control)
+            && event.modifierFlags.intersection([.command, .option, .shift]).isEmpty
+            && (event.keyCode == 9 || event.charactersIgnoringModifiers?.lowercased() == "v")
     }
 }

--- a/Screendrop/PreviewWindowView.swift
+++ b/Screendrop/PreviewWindowView.swift
@@ -8,6 +8,7 @@
 //
 
 import AppKit
+import CoreGraphics
 import SwiftUI
 
 let previewCardSize = CGSize(width: 165, height: 124)
@@ -31,6 +32,7 @@ struct PreviewWindowView: View {
     @State private var stackHeight: CGFloat = 500
     @State private var peekHeight: CGFloat = 64
     @AppStorage(ScreendropPreferences.previewPositionKey) private var previewPositionRaw = PreviewOverlayPosition.right.rawValue
+    @AppStorage(ScreendropPreferences.previewCloseAfterPastingKey) private var previewCloseAfterPasting = false
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismiss) private var dismissWindow
 
@@ -135,6 +137,11 @@ struct PreviewWindowView: View {
             installScrollMonitor()
         }
         .onDisappear(perform: tearDown)
+        .onChange(of: previewCloseAfterPasting) { _, isEnabled in
+            if isEnabled {
+                requestInputMonitoringAccessIfNeeded()
+            }
+        }
         .onChange(of: previewStack.items.count) { _, count in
             if count == 0 {
                 if let onRequestClose {
@@ -303,9 +310,18 @@ struct PreviewWindowView: View {
     }
     
     // MARK: - Keyboard
+
+    /// Requests listen access only for the paste-dismissal feature; keeping the
+    /// prompt opt-in avoids asking screenshot-only users for input monitoring.
+    private func requestInputMonitoringAccessIfNeeded() {
+        guard previewCloseAfterPasting, !CGPreflightListenEventAccess() else { return }
+        _ = CGRequestListenEventAccess()
+    }
     
     private func installKeyMonitors() {
         guard keyMonitor == nil, globalKeyMonitor == nil else { return }
+
+        requestInputMonitoringAccessIfNeeded()
         
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             if handlePreviewKey(event) {

--- a/Screendrop/ScreendropPreferences.swift
+++ b/Screendrop/ScreendropPreferences.swift
@@ -30,6 +30,7 @@ enum ScreendropPreferences {
     static let previewPositionKey = "previewPosition"
     static let previewAutoCloseSecondsKey = "previewAutoCloseSeconds"
     static let previewCloseAfterDraggingKey = "previewCloseAfterDragging"
+    static let previewCloseAfterPastingKey = "previewCloseAfterPasting"
     static let overlayCardLayoutKey = "overlayCardLayout"
     static let lowResolutionEditorPreviewKey = "lowResolutionEditorPreview"
     static let trimFullscreenMenuBarKey = "trimFullscreenMenuBar"
@@ -192,6 +193,12 @@ enum ScreendropPreferences {
             return true
         }
         return UserDefaults.standard.bool(forKey: previewCloseAfterDraggingKey)
+    }
+
+    /// Whether Ctrl+V closes a preview after an automatic image copy. Defaults
+    /// to off because it observes paste shortcuts outside Screendrop.
+    static var previewCloseAfterPasting: Bool {
+        UserDefaults.standard.bool(forKey: previewCloseAfterPastingKey)
     }
 
     /// Whether the annotation editor displays a downscaled preview of the

--- a/Screendrop/ScreenshotPreviewStack.swift
+++ b/Screendrop/ScreenshotPreviewStack.swift
@@ -43,6 +43,9 @@ final class ScreenshotPreviewStack {
     @ObservationIgnored private var overlayExitTask: Task<Void, Never>?
     @ObservationIgnored private var compressionTasks: [ScreenshotPreviewItem.ID: Task<Void, Never>] = [:]
     @ObservationIgnored private var compressionBadgeTasks: [ScreenshotPreviewItem.ID: Task<Void, Never>] = [:]
+    /// Pasteboard version and preview item for the last automatic image copy,
+    /// used by the prototype Ctrl+V auto-dismiss behavior.
+    @ObservationIgnored private var copiedImagePasteboardState: (itemID: ScreenshotPreviewItem.ID, changeCount: Int)?
     private var visibleCapacity: Int?
 
     var itemIDs: [ScreenshotPreviewItem.ID] {
@@ -63,6 +66,22 @@ final class ScreenshotPreviewStack {
 
     var hasUnsavedItems: Bool {
         !unsavedItems.isEmpty
+    }
+
+    /// Whether the automatically copied image is still current, allowing Ctrl+V
+    /// to dismiss the expanded preview without reacting to stale clipboard data.
+    var isPasteDismissalReady: Bool {
+        guard ScreendropPreferences.previewCloseAfterPasting,
+              AfterCaptureActions.isEnabled(.copy, for: .screenshot),
+              !items.isEmpty,
+              !isCollapsed,
+              !isExiting,
+              let copiedImagePasteboardState,
+              items.contains(where: { $0.id == copiedImagePasteboardState.itemID }) else {
+            return false
+        }
+
+        return NSPasteboard.general.changeCount == copiedImagePasteboardState.changeCount
     }
 
     private init() {}
@@ -107,7 +126,11 @@ final class ScreenshotPreviewStack {
         if AfterCaptureActions.isEnabled(.copy, for: type) {
             switch type {
             case .screenshot:
-                _ = copyURLToClipboard(url)
+                _ = copyURLToClipboard(
+                    url,
+                    itemID: itemID,
+                    tracksPasteDismissal: true
+                )
             case .recording:
                 Task { _ = await copyVideoURLToClipboard(url, itemID: itemID) }
             }
@@ -396,7 +419,11 @@ final class ScreenshotPreviewStack {
 
         switch item.kind {
         case .image:
-            guard copyURLToClipboard(item.url) else { return }
+            guard copyURLToClipboard(
+                item.url,
+                itemID: id,
+                tracksPasteDismissal: false
+            ) else { return }
             dismiss(id: id)
         case .video:
             // Flattening can take a moment, so the card stays up showing
@@ -630,7 +657,11 @@ final class ScreenshotPreviewStack {
         }
 
         if ScreendropPreferences.autoCopy {
-            _ = copyURLToClipboard(item.url)
+            _ = copyURLToClipboard(
+                item.url,
+                itemID: item.id,
+                tracksPasteDismissal: true
+            )
         }
     }
 
@@ -786,9 +817,19 @@ final class ScreenshotPreviewStack {
         compressionResultBadges.removeAll()
     }
 
-    private func copyURLToClipboard(_ url: URL) -> Bool {
+    private func copyURLToClipboard(
+        _ url: URL,
+        itemID: ScreenshotPreviewItem.ID,
+        tracksPasteDismissal: Bool
+    ) -> Bool {
         do {
             try ScreenshotFileActions.copyImageToClipboard(from: url)
+            if tracksPasteDismissal {
+                copiedImagePasteboardState = (
+                    itemID: itemID,
+                    changeCount: NSPasteboard.general.changeCount
+                )
+            }
             return true
         } catch {
             print("Failed to copy screenshot: \(error)")

--- a/Screendrop/SettingsPlaceholderPanes.swift
+++ b/Screendrop/SettingsPlaceholderPanes.swift
@@ -46,6 +46,7 @@ struct OverlaySettingsPane: View {
     @AppStorage(ScreendropPreferences.previewPositionKey) private var previewPositionRaw = PreviewOverlayPosition.right.rawValue
     @AppStorage(ScreendropPreferences.previewAutoCloseSecondsKey) private var autoCloseSeconds = 0
     @AppStorage(ScreendropPreferences.previewCloseAfterDraggingKey) private var closeAfterDragging = true
+    @AppStorage(ScreendropPreferences.previewCloseAfterPastingKey) private var closeAfterPasting = false
 
     private let autoCloseOptions: [Int] = [0, 5, 10, 30, 60]
 
@@ -82,6 +83,16 @@ struct OverlaySettingsPane: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Close after dragging")
                         Text("Dismiss the preview once you drag it out to another app.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
+
+                Toggle(isOn: $closeAfterPasting) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Close after pasting")
+                        Text("When Copy to clipboard is enabled, dismiss the preview after you paste with Ctrl+V.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }


### PR DESCRIPTION
## Summary
- optionally dismiss an expanded screenshot preview after pasting with Ctrl+V
- track automatic image copies so stale or manually copied clipboard contents do not dismiss the preview
- add a Preview Overlay option to enable the behavior

Transparency notice: This was made with GPT 5.6 Luna Max.