### PR TITLE
Speed up studio export without touching quality settings

### DIFF
--- a/Screendrop.xcodeproj/project.pbxproj
+++ b/Screendrop.xcodeproj/project.pbxproj
@@ -9,16 +9,24 @@
 /* Begin PBXBuildFile section */
 		31A100022F9DC05A002A7AF3 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 31A100012F9DC05A002A7AF3 /* Sparkle */; };
 		5EB13EE1F16DFCBCFE9A3449 /* DockProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 6711E7AD88BD96C1258D3CE6 /* DockProgress */; };
+		A1B2C3D4E5F600000000B101 /* StudioSourceImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000B001 /* StudioSourceImageCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		3163891D2F9DC05A002A7AF3 /* Screendrop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Screendrop.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B2C3D4E5F600000000A002 /* ScreendropTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScreendropTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B2C3D4E5F600000000B001 /* StudioSourceImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StudioSourceImageCache.swift; path = Screendrop/StudioSourceImageCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		3163891F2F9DC05A002A7AF3 /* Screendrop */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Screendrop;
+			sourceTree = "<group>";
+		};
+		A1B2C3D4E5F600000000A001 /* ScreendropTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ScreendropTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -33,6 +41,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A1B2C3D4E5F600000000A005 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -40,6 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				3163891F2F9DC05A002A7AF3 /* Screendrop */,
+				A1B2C3D4E5F600000000A001 /* ScreendropTests */,
 				3163891E2F9DC05A002A7AF3 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -48,6 +64,7 @@
 			isa = PBXGroup;
 			children = (
 				3163891D2F9DC05A002A7AF3 /* Screendrop.app */,
+				A1B2C3D4E5F600000000A002 /* ScreendropTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -79,6 +96,28 @@
 			productReference = 3163891D2F9DC05A002A7AF3 /* Screendrop.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A1B2C3D4E5F600000000A003 /* ScreendropTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1B2C3D4E5F600000000A009 /* Build configuration list for PBXNativeTarget "ScreendropTests" */;
+			buildPhases = (
+				A1B2C3D4E5F600000000A004 /* Sources */,
+				A1B2C3D4E5F600000000A005 /* Frameworks */,
+				A1B2C3D4E5F600000000A006 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A1B2C3D4E5F600000000A001 /* ScreendropTests */,
+			);
+			name = ScreendropTests;
+			packageProductDependencies = (
+			);
+			productName = ScreendropTests;
+			productReference = A1B2C3D4E5F600000000A002 /* ScreendropTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -91,6 +130,9 @@
 				TargetAttributes = {
 					3163891C2F9DC05A002A7AF3 = {
 						CreatedOnToolsVersion = 26.4;
+					};
+					A1B2C3D4E5F600000000A003 = {
+						CreatedOnToolsVersion = 26.6;
 					};
 				};
 			};
@@ -113,12 +155,20 @@
 			projectRoot = "";
 			targets = (
 				3163891C2F9DC05A002A7AF3 /* Screendrop */,
+				A1B2C3D4E5F600000000A003 /* ScreendropTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3163891B2F9DC05A002A7AF3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B2C3D4E5F600000000A006 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -132,6 +182,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B2C3D4E5F600000000A004 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B2C3D4E5F600000000B101 /* StudioSourceImageCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -448,6 +506,63 @@
 			};
 			name = "Debug Dev";
 		};
+		A1B2C3D4E5F600000000A00A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TB2S44TFQS;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fayazahmed.ScreendropTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A1B2C3D4E5F600000000A00B /* Debug Dev */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TB2S44TFQS;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fayazahmed.ScreendropTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Debug Dev";
+		};
+		A1B2C3D4E5F600000000A00C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TB2S44TFQS;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fayazahmed.ScreendropTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -467,6 +582,16 @@
 				316389292F9DC05B002A7AF3 /* Debug */,
 				31CA951B2FCB2749003035C6 /* Debug Dev */,
 				3163892A2F9DC05B002A7AF3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1B2C3D4E5F600000000A009 /* Build configuration list for PBXNativeTarget "ScreendropTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1B2C3D4E5F600000000A00A /* Debug */,
+				A1B2C3D4E5F600000000A00B /* Debug Dev */,
+				A1B2C3D4E5F600000000A00C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Screendrop.xcodeproj/project.pbxproj
+++ b/Screendrop.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		31A100022F9DC05A002A7AF3 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 31A100012F9DC05A002A7AF3 /* Sparkle */; };
 		5EB13EE1F16DFCBCFE9A3449 /* DockProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 6711E7AD88BD96C1258D3CE6 /* DockProgress */; };
 		A1B2C3D4E5F600000000B101 /* StudioSourceImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000B001 /* StudioSourceImageCache.swift */; };
+		A1B2C3D4E5F600000000B102 /* PrefetchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000B002 /* PrefetchQueue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		3163891D2F9DC05A002A7AF3 /* Screendrop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Screendrop.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D4E5F600000000A002 /* ScreendropTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScreendropTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D4E5F600000000B001 /* StudioSourceImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StudioSourceImageCache.swift; path = Screendrop/StudioSourceImageCache.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000000B002 /* PrefetchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrefetchQueue.swift; path = Screendrop/PrefetchQueue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -190,6 +192,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A1B2C3D4E5F600000000B101 /* StudioSourceImageCache.swift in Sources */,
+				A1B2C3D4E5F600000000B102 /* PrefetchQueue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Screendrop.xcodeproj/project.pbxproj
+++ b/Screendrop.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		5EB13EE1F16DFCBCFE9A3449 /* DockProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 6711E7AD88BD96C1258D3CE6 /* DockProgress */; };
 		A1B2C3D4E5F600000000B101 /* StudioSourceImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000B001 /* StudioSourceImageCache.swift */; };
 		A1B2C3D4E5F600000000B102 /* PrefetchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000B002 /* PrefetchQueue.swift */; };
+		A1B2C3D4E5F600000000B103 /* OrderedConcurrentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000B003 /* OrderedConcurrentRenderer.swift */; };
+		A1B2C3D4E5F600000000B104 /* ResourcePool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000B004 /* ResourcePool.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -18,6 +20,8 @@
 		A1B2C3D4E5F600000000A002 /* ScreendropTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScreendropTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D4E5F600000000B001 /* StudioSourceImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StudioSourceImageCache.swift; path = Screendrop/StudioSourceImageCache.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F600000000B002 /* PrefetchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrefetchQueue.swift; path = Screendrop/PrefetchQueue.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000000B003 /* OrderedConcurrentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OrderedConcurrentRenderer.swift; path = Screendrop/OrderedConcurrentRenderer.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000000B004 /* ResourcePool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ResourcePool.swift; path = Screendrop/ResourcePool.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -193,6 +197,8 @@
 			files = (
 				A1B2C3D4E5F600000000B101 /* StudioSourceImageCache.swift in Sources */,
 				A1B2C3D4E5F600000000B102 /* PrefetchQueue.swift in Sources */,
+				A1B2C3D4E5F600000000B103 /* OrderedConcurrentRenderer.swift in Sources */,
+				A1B2C3D4E5F600000000B104 /* ResourcePool.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Screendrop.xcodeproj/xcshareddata/xcschemes/Screendrop.xcscheme
+++ b/Screendrop.xcodeproj/xcshareddata/xcschemes/Screendrop.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F600000000A003"
+               BuildableName = "ScreendropTests.xctest"
+               BlueprintName = "ScreendropTests"
+               ReferencedContainer = "container:Screendrop.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Screendrop/OrderedConcurrentRenderer.swift
+++ b/Screendrop/OrderedConcurrentRenderer.swift
@@ -1,0 +1,79 @@
+//
+//  OrderedConcurrentRenderer.swift
+//  Screendrop
+//
+//  Runs an independent per-item transform over an ordered stream and
+//  delivers the results in submission order.
+//
+//  Compositing one export frame depends only on its own timestamps, so
+//  frames can be drawn on as many cores as are free. `AVAssetWriter` still
+//  requires appends in presentation order, which is what this type
+//  reconciles.
+//
+//  The design is a FIFO of in-flight tasks. Awaiting the oldest one first
+//  gives submission order for free, and refusing to start a new task until
+//  the queue is under its cap gives the concurrency bound for free.
+//
+//  Single-producer: `submit` and `finish` are meant to be called from one
+//  task, which is how the export's frame loop drives it.
+//
+
+import Foundation
+
+nonisolated final class OrderedConcurrentRenderer<Input: Sendable, Output: Sendable> {
+    private let concurrency: Int
+    private let render: @Sendable (Input) async throws -> Output
+    private let emit: (Output) async throws -> Void
+    private var inFlight: [Task<Output, Error>] = []
+
+    /// - Parameters:
+    ///   - concurrency: how many items may render at once. Each in-flight
+    ///     item holds a full-size destination buffer, so this bounds peak
+    ///     memory as much as it bounds CPU.
+    ///   - render: the independent per-item work.
+    ///   - emit: receives outputs in submission order, one at a time.
+    init(
+        concurrency: Int,
+        render: @escaping @Sendable (Input) async throws -> Output,
+        emit: @escaping (Output) async throws -> Void
+    ) {
+        self.concurrency = max(1, concurrency)
+        self.render = render
+        self.emit = emit
+    }
+
+    func submit(_ input: Input) async throws {
+        if inFlight.count >= concurrency {
+            try await emitOldest()
+        }
+        let render = self.render
+        inFlight.append(Task { try await render(input) })
+    }
+
+    /// Drains everything still rendering, in order.
+    func finish() async throws {
+        while !inFlight.isEmpty {
+            try await emitOldest()
+        }
+    }
+
+    /// Cancels every in-flight item and drops it undelivered.
+    func cancel() {
+        for task in inFlight {
+            task.cancel()
+        }
+        inFlight.removeAll()
+    }
+
+    private func emitOldest() async throws {
+        let oldest = inFlight.removeFirst()
+        do {
+            try await emit(oldest.value)
+        } catch {
+            // One failed frame makes the rest pointless, and leaving them
+            // running would outlive the writer they were drawing for.
+            cancel()
+            throw error
+        }
+    }
+}

--- a/Screendrop/PrefetchQueue.swift
+++ b/Screendrop/PrefetchQueue.swift
@@ -1,0 +1,118 @@
+//
+//  PrefetchQueue.swift
+//  Screendrop
+//
+//  Hands the results of a blocking producer to an async consumer in
+//  production order, so decoding a movie can overlap with the work that
+//  consumes each decoded frame.
+//
+//  The producer runs on its own thread because the calls it wraps -
+//  `AVAssetReaderOutput.copyNextSampleBuffer()` above all - block. Keeping
+//  that off the cooperative pool is the point of the type.
+//
+//  Single-consumer: `next()` is meant to be called from one task at a
+//  time, which is how the export's frame loop uses it.
+//
+
+import Foundation
+
+nonisolated final class PrefetchQueue<Element: Sendable>: @unchecked Sendable {
+    private let capacity: Int
+    private let produce: @Sendable () -> Element?
+
+    private let lock = NSCondition()
+    private var buffer: [Element] = []
+    private var waiting: [CheckedContinuation<Element?, Never>] = []
+    private var isFinished = false
+    private var isCancelled = false
+
+    /// - Parameters:
+    ///   - capacity: how many produced elements may sit undelivered before
+    ///     the producer is made to wait. Bounds memory: each buffered
+    ///     screen frame is a full-size pixel buffer.
+    ///   - produce: returns the next element, or nil at end of stream.
+    init(capacity: Int, produce: @escaping @Sendable () -> Element?) {
+        self.capacity = max(1, capacity)
+        self.produce = produce
+        startProducer()
+    }
+
+    /// The next element in production order, or nil once the producer has
+    /// reached end of stream or the queue was cancelled.
+    func next() async -> Element? {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if !buffer.isEmpty {
+                let element = buffer.removeFirst()
+                lock.signal()
+                lock.unlock()
+                continuation.resume(returning: element)
+            } else if isFinished || isCancelled {
+                lock.unlock()
+                continuation.resume(returning: nil)
+            } else {
+                waiting.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    /// Stops production and releases any consumer waiting on `next()`.
+    /// Callers must invoke this on every exit path, including errors, or
+    /// the producer thread keeps the queue alive.
+    func cancel() {
+        lock.lock()
+        isCancelled = true
+        let pending = waiting
+        waiting.removeAll()
+        buffer.removeAll()
+        lock.broadcast()
+        lock.unlock()
+        pending.forEach { $0.resume(returning: nil) }
+    }
+
+    private func startProducer() {
+        let thread = Thread { [self] in runProducer() }
+        thread.name = "com.fayazahmed.Screendrop.PrefetchQueue"
+        thread.qualityOfService = .userInitiated
+        thread.start()
+    }
+
+    private func runProducer() {
+        while true {
+            lock.lock()
+            while buffer.count >= capacity, !isCancelled, waiting.isEmpty {
+                lock.wait()
+            }
+            if isCancelled {
+                lock.unlock()
+                return
+            }
+            lock.unlock()
+
+            let element = produce()
+
+            lock.lock()
+            if isCancelled {
+                lock.unlock()
+                return
+            }
+            guard let element else {
+                isFinished = true
+                let pending = waiting
+                waiting.removeAll()
+                lock.unlock()
+                pending.forEach { $0.resume(returning: nil) }
+                return
+            }
+            if waiting.isEmpty {
+                buffer.append(element)
+                lock.unlock()
+            } else {
+                let consumer = waiting.removeFirst()
+                lock.unlock()
+                consumer.resume(returning: element)
+            }
+        }
+    }
+}

--- a/Screendrop/RecordingStudioExporter.swift
+++ b/Screendrop/RecordingStudioExporter.swift
@@ -133,6 +133,32 @@ nonisolated final class RecordingStudioExporter: @unchecked Sendable {
         let time: TimeInterval
     }
 
+    /// One frame's worth of already-resolved inputs, handed to a worker.
+    /// Everything ordered has been settled by the time one of these exists.
+    private struct FrameJob: @unchecked Sendable {
+        let screenBuffer: CVPixelBuffer
+        let cameraBuffer: CVPixelBuffer?
+        let editorTime: TimeInterval
+        let sourceTime: TimeInterval
+        let index: Int
+    }
+
+    /// A composited frame waiting its turn to be appended. The writer needs
+    /// presentation order, which workers finishing out of order cannot give.
+    private struct RenderedFrame: @unchecked Sendable {
+        let buffer: CVPixelBuffer
+        let editorTime: TimeInterval
+        let index: Int
+    }
+
+    /// How many frames composite at once. Two cores stay free for the
+    /// decoder thread and the encoder, and the ceiling bounds memory: every
+    /// frame in flight holds a full-size destination buffer, which is
+    /// 74.6 MB at 5760x3240.
+    private static var compositingConcurrency: Int {
+        min(4, max(2, ProcessInfo.processInfo.activeProcessorCount - 2))
+    }
+
     private final class CancelFlag: @unchecked Sendable {
         private let lock = NSLock()
         private var cancelled = false
@@ -405,66 +431,107 @@ nonisolated final class RecordingStudioExporter: @unchecked Sendable {
         }
         defer { sourceFrames.cancel() }
 
+        // Compositing one frame depends only on its own timestamps, so
+        // frames draw on as many cores as are free. Everything ordered stays
+        // on this task: walking the clip timeline, advancing the source
+        // reader, and pulling camera frames, since `CameraFrameFeed` is a
+        // sequential decoder that assumes rising source times.
+        let workerCount = Self.compositingConcurrency
+        let compositors = ResourcePool(
+            (0..<workerCount).map { _ in compositor.makeWorkerCopy() }
+        )
+        nonisolated(unsafe) let bufferAdaptor = adaptor
+        nonisolated(unsafe) let writerInput = input
+
+        let renderer = OrderedConcurrentRenderer<FrameJob, RenderedFrame>(
+            concurrency: workerCount,
+            render: { job in
+                guard let worker = compositors.borrow() else {
+                    throw ExportError.writerFailed(nil)
+                }
+                defer { compositors.giveBack(worker) }
+                guard let pixelBufferPool = bufferAdaptor.pixelBufferPool else {
+                    throw ExportError.writerFailed(nil)
+                }
+                var destination: CVPixelBuffer?
+                CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pixelBufferPool, &destination)
+                guard let destination else {
+                    throw ExportError.writerFailed(nil)
+                }
+                try worker.render(
+                    screenFrame: job.screenBuffer,
+                    cameraFrame: job.cameraBuffer,
+                    editorTime: job.editorTime,
+                    sourceTime: job.sourceTime,
+                    into: destination
+                )
+                return RenderedFrame(
+                    buffer: destination,
+                    editorTime: job.editorTime,
+                    index: job.index
+                )
+            },
+            emit: { rendered in
+                // Waiting on the writer here rather than before compositing
+                // means the workers keep drawing while it catches up.
+                while !writerInput.isReadyForMoreMediaData {
+                    if cancelFlag.isCancelled { throw ExportError.cancelled }
+                    try await Task.sleep(nanoseconds: 2_000_000)
+                }
+                let pts = CMTime(seconds: rendered.editorTime, preferredTimescale: 600)
+                if !bufferAdaptor.append(rendered.buffer, withPresentationTime: pts) {
+                    throw ExportError.writerFailed(nil)
+                }
+                if rendered.index % 10 == 0 {
+                    progress(min(0.98, Double(rendered.index) / Double(frameCount)))
+                }
+            }
+        )
+
         var currentBuffer: CVPixelBuffer?
         var pending = await sourceFrames.next()
         var previousClipID: UUID?
 
-        for frame in 0..<frameCount {
-            if cancelFlag.isCancelled { throw ExportError.cancelled }
-            let editorTime = Double(frame) / frameRate
-            guard let location = clipTimeline.location(at: editorTime) else { break }
-            let sourceTime = location.sourceTime
-
-            if previousClipID != location.segmentID {
-                // Never carry a sparse screen-capture frame across a hard
-                // edit boundary - the reader may not have caught up yet to
-                // the new clip's starting source position.
-                if previousClipID != nil {
-                    currentBuffer = nil
-                }
-                previousClipID = location.segmentID
-            }
-
-            while let sample = pending, sample.time <= editorTime {
-                currentBuffer = sample.buffer
-                pending = await sourceFrames.next()
-            }
-            // Ticks before the first source frame show it early rather than
-            // emitting black; a capture with no frames at all has nothing to
-            // render.
-            guard let sourceBuffer = currentBuffer ?? pending?.buffer else { break }
-
-            while !input.isReadyForMoreMediaData {
+        do {
+            for frame in 0..<frameCount {
                 if cancelFlag.isCancelled { throw ExportError.cancelled }
-                try await Task.sleep(nanoseconds: 2_000_000)
-            }
+                let editorTime = Double(frame) / frameRate
+                guard let location = clipTimeline.location(at: editorTime) else { break }
+                let sourceTime = location.sourceTime
 
-            guard let pool = adaptor.pixelBufferPool else {
-                throw ExportError.writerFailed(nil)
-            }
-            var destinationBuffer: CVPixelBuffer?
-            CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &destinationBuffer)
-            guard let destinationBuffer else {
-                throw ExportError.writerFailed(nil)
-            }
+                if previousClipID != location.segmentID {
+                    // Never carry a sparse screen-capture frame across a hard
+                    // edit boundary - the reader may not have caught up yet to
+                    // the new clip's starting source position.
+                    if previousClipID != nil {
+                        currentBuffer = nil
+                    }
+                    previousClipID = location.segmentID
+                }
 
-            let cameraBuffer = cameraFeed?.latestFrame(at: sourceTime)
-            try compositor.render(
-                screenFrame: sourceBuffer,
-                cameraFrame: cameraBuffer,
-                editorTime: editorTime,
-                sourceTime: sourceTime,
-                into: destinationBuffer
-            )
+                while let sample = pending, sample.time <= editorTime {
+                    currentBuffer = sample.buffer
+                    pending = await sourceFrames.next()
+                }
+                // Ticks before the first source frame show it early rather than
+                // emitting black; a capture with no frames at all has nothing to
+                // render.
+                guard let sourceBuffer = currentBuffer ?? pending?.buffer else { break }
 
-            let pts = CMTime(seconds: editorTime, preferredTimescale: 600)
-            if !adaptor.append(destinationBuffer, withPresentationTime: pts) {
-                throw ExportError.writerFailed(nil)
+                try await renderer.submit(
+                    FrameJob(
+                        screenBuffer: sourceBuffer,
+                        cameraBuffer: cameraFeed?.latestFrame(at: sourceTime),
+                        editorTime: editorTime,
+                        sourceTime: sourceTime,
+                        index: frame
+                    )
+                )
             }
-
-            if frame % 10 == 0 {
-                progress(min(0.98, Double(frame) / Double(frameCount)))
-            }
+            try await renderer.finish()
+        } catch {
+            renderer.cancel()
+            throw error
         }
         input.markAsFinished()
     }
@@ -675,6 +742,38 @@ nonisolated private final class StudioFrameCompositor: @unchecked Sendable {
             style: style,
             colorSpace: colorSpace
         )
+    }
+
+    /// A sibling for another frame worker. Everything costly is immutable
+    /// and shared by reference - the layout maths and the pre-rendered
+    /// backdrop above all - while the caches are fresh, because none of
+    /// them is thread-safe. Building one is cheap; building a compositor
+    /// per frame would not be, since a cold one re-decodes the pointer
+    /// artwork.
+    private init(sharing other: StudioFrameCompositor) {
+        canvasSize = other.canvasSize
+        videoCropRect = other.videoCropRect
+        layout = other.layout
+        viewportTimeline = other.viewportTimeline
+        pointerTimeline = other.pointerTimeline
+        showsPressEffects = other.showsPressEffects
+        keystrokeTimeline = other.keystrokeTimeline
+        keystrokePlacement = other.keystrokePlacement
+        subtitleTimeline = other.subtitleTimeline
+        subtitleStyle = other.subtitleStyle
+        karaokeTimeline = other.karaokeTimeline
+        reframe = other.reframe
+        pointerScale = other.pointerScale
+        colorSpace = other.colorSpace
+        backdrop = other.backdrop
+        outputFrameInterval = other.outputFrameInterval
+        artworkImageCache = other.artworkImageCache
+        screenImageCache = StudioSourceImageCache(colorSpace: other.colorSpace)
+        cameraImageCache = StudioSourceImageCache(colorSpace: other.colorSpace)
+    }
+
+    func makeWorkerCopy() -> StudioFrameCompositor {
+        StudioFrameCompositor(sharing: self)
     }
 
     /// The virtual camera for a frame: the reframe crop-and-follow track

--- a/Screendrop/RecordingStudioExporter.swift
+++ b/Screendrop/RecordingStudioExporter.swift
@@ -597,6 +597,11 @@ nonisolated private final class StudioFrameCompositor: @unchecked Sendable {
     private let pointerScale: CGFloat
     private let colorSpace: CGColorSpace
     private let backdrop: CGImage?
+    /// The output clock ticks faster than a sparse screen capture emits
+    /// frames, so consecutive ticks routinely draw the same source buffer.
+    /// One slot per stream turns those repeats into a lookup.
+    private let screenImageCache: StudioSourceImageCache
+    private let cameraImageCache: StudioSourceImageCache
     /// Fixed output cadence, matching `pumpVideo`'s frame clock. Since the
     /// output timeline is gapless by construction, the shutter window for
     /// motion-blur supersampling is always exactly one output frame - no
@@ -641,7 +646,10 @@ nonisolated private final class StudioFrameCompositor: @unchecked Sendable {
         self.reframe = reframe
         self.outputFrameInterval = outputFrameInterval
         self.pointerScale = style.cursorScale
-        self.colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        self.colorSpace = colorSpace
+        self.screenImageCache = StudioSourceImageCache(colorSpace: colorSpace)
+        self.cameraImageCache = StudioSourceImageCache(colorSpace: colorSpace)
         self.backdrop = Self.renderBackdrop(
             canvasSize: canvasSize,
             layout: layout,
@@ -688,7 +696,7 @@ nonisolated private final class StudioFrameCompositor: @unchecked Sendable {
             context.fill(CGRect(origin: .zero, size: canvasSize))
         }
 
-        if let screenImage = Self.makeImage(from: screenFrame, colorSpace: colorSpace) {
+        if let screenImage = screenImageCache.image(for: screenFrame) {
             // Motion blur by temporal supersampling: while the virtual camera
             // is moving, average several sub-frame camera states across the
             // frame's shutter interval. Pans smear linearly, zooms radially,
@@ -727,7 +735,7 @@ nonisolated private final class StudioFrameCompositor: @unchecked Sendable {
 
         if let cameraFrame,
            layout.bubbleRect.width > 0,
-           let cameraImage = Self.makeImage(from: cameraFrame, colorSpace: colorSpace) {
+           let cameraImage = cameraImageCache.image(for: cameraFrame) {
             let bubble = layout.bubbleRect
             let imageSize = CGSize(width: cameraImage.width, height: cameraImage.height)
             let scale = max(bubble.width / imageSize.width, bubble.height / imageSize.height)
@@ -1116,25 +1124,6 @@ nonisolated private final class StudioFrameCompositor: @unchecked Sendable {
             cornerHeight: boundedRadius,
             transform: nil
         )
-    }
-
-    private static func makeImage(from pixelBuffer: CVPixelBuffer, colorSpace: CGColorSpace) -> CGImage? {
-        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
-        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
-
-        guard let base = CVPixelBufferGetBaseAddress(pixelBuffer),
-              let context = CGContext(
-                data: base,
-                width: CVPixelBufferGetWidth(pixelBuffer),
-                height: CVPixelBufferGetHeight(pixelBuffer),
-                bitsPerComponent: 8,
-                bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
-                space: colorSpace,
-                bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
-              ) else {
-            return nil
-        }
-        return context.makeImage()
     }
 
     private static func renderBackdrop(

--- a/Screendrop/RecordingStudioExporter.swift
+++ b/Screendrop/RecordingStudioExporter.swift
@@ -124,6 +124,15 @@ nonisolated final class RecordingStudioExporter: @unchecked Sendable {
         }
     }
 
+    /// One decoded screen frame on its way from the reader thread to the
+    /// compositing loop. `CVPixelBuffer` carries no Sendable conformance,
+    /// but ownership passes hand to hand here - the producer drops its
+    /// reference the moment it hands the frame over.
+    private struct SourceFrame: @unchecked Sendable {
+        let buffer: CVPixelBuffer
+        let time: TimeInterval
+    }
+
     private final class CancelFlag: @unchecked Sendable {
         private let lock = NSLock()
         private var cancelled = false
@@ -378,16 +387,26 @@ nonisolated final class RecordingStudioExporter: @unchecked Sendable {
         let duration = clipTimeline.duration
         let frameCount = max(1, Int((duration * frameRate).rounded()))
 
-        func nextSourceFrame() -> (buffer: CVPixelBuffer, time: TimeInterval)? {
-            while let sampleBuffer = output.copyNextSampleBuffer() {
+        // Decoding used to run inline in this loop, so a frame was never
+        // decoded while another was being drawn. The queue moves the
+        // blocking reader onto its own thread and keeps a small look-ahead.
+        // The bound stays low deliberately: every buffered frame is a
+        // full-size pixel buffer held out of the reader's pool.
+        nonisolated(unsafe) let trackOutput = output
+        let sourceFrames = PrefetchQueue<SourceFrame>(capacity: 3) {
+            while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
                 guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { continue }
-                return (buffer, CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds)
+                return SourceFrame(
+                    buffer: buffer,
+                    time: CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds
+                )
             }
             return nil
         }
+        defer { sourceFrames.cancel() }
 
         var currentBuffer: CVPixelBuffer?
-        var pending = nextSourceFrame()
+        var pending = await sourceFrames.next()
         var previousClipID: UUID?
 
         for frame in 0..<frameCount {
@@ -408,7 +427,7 @@ nonisolated final class RecordingStudioExporter: @unchecked Sendable {
 
             while let sample = pending, sample.time <= editorTime {
                 currentBuffer = sample.buffer
-                pending = nextSourceFrame()
+                pending = await sourceFrames.next()
             }
             // Ticks before the first source frame show it early rather than
             // emitting black; a capture with no frames at all has nothing to

--- a/Screendrop/ResourcePool.swift
+++ b/Screendrop/ResourcePool.swift
@@ -1,0 +1,34 @@
+//
+//  ResourcePool.swift
+//  Screendrop
+//
+//  A fixed set of reusable workers, lent one at a time. Used for objects
+//  that are expensive to build and unsafe to share - the studio export's
+//  per-frame compositors above all.
+//
+
+import Foundation
+
+nonisolated final class ResourcePool<Resource>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var available: [Resource]
+
+    init(_ resources: [Resource]) {
+        available = resources
+    }
+
+    /// Takes a resource out of the pool, or nil when all are lent out.
+    func borrow() -> Resource? {
+        lock.lock()
+        defer { lock.unlock() }
+        return available.isEmpty ? nil : available.removeLast()
+    }
+
+    /// Returns a borrowed resource. Callers must do this on every exit
+    /// path, or the pool drains.
+    func giveBack(_ resource: Resource) {
+        lock.lock()
+        defer { lock.unlock() }
+        available.append(resource)
+    }
+}

--- a/Screendrop/StudioSourceImageCache.swift
+++ b/Screendrop/StudioSourceImageCache.swift
@@ -1,0 +1,57 @@
+//
+//  StudioSourceImageCache.swift
+//  Screendrop
+//
+//  Turns a screen-capture pixel buffer into the CGImage the studio
+//  compositor draws. The export renders on a fixed output clock while a
+//  screen capture only emits frames where pixels changed, so consecutive
+//  output frames routinely share one source buffer.
+//
+
+import CoreGraphics
+import CoreVideo
+
+/// Not thread-safe by design: it holds one slot, so each compositing worker
+/// owns its own instance rather than sharing one behind a lock.
+nonisolated final class StudioSourceImageCache {
+    private let colorSpace: CGColorSpace
+    private var cachedBuffer: CVPixelBuffer?
+    private var cachedImage: CGImage?
+
+    init(colorSpace: CGColorSpace) {
+        self.colorSpace = colorSpace
+    }
+
+    func image(for buffer: CVPixelBuffer) -> CGImage? {
+        if let cachedBuffer, cachedBuffer === buffer, let cachedImage {
+            return cachedImage
+        }
+        let image = Self.makeImage(from: buffer, colorSpace: colorSpace)
+        cachedBuffer = buffer
+        cachedImage = image
+        return image
+    }
+
+    private static func makeImage(
+        from pixelBuffer: CVPixelBuffer,
+        colorSpace: CGColorSpace
+    ) -> CGImage? {
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+
+        guard let base = CVPixelBufferGetBaseAddress(pixelBuffer),
+              let context = CGContext(
+                data: base,
+                width: CVPixelBufferGetWidth(pixelBuffer),
+                height: CVPixelBufferGetHeight(pixelBuffer),
+                bitsPerComponent: 8,
+                bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                    | CGBitmapInfo.byteOrder32Little.rawValue
+              ) else {
+            return nil
+        }
+        return context.makeImage()
+    }
+}

--- a/ScreendropTests/OrderedConcurrentRendererTests.swift
+++ b/ScreendropTests/OrderedConcurrentRendererTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+/// Compositing a frame is a pure function of its time, so frames can be
+/// drawn concurrently. `AVAssetWriter` still needs them appended in
+/// presentation order, so the renderer has to reorder completions.
+final class OrderedConcurrentRendererTests: XCTestCase {
+    private final class LockedBox<Value>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: Value
+
+        init(_ value: Value) { storage = value }
+
+        func withLock<Result>(_ body: (inout Value) -> Result) -> Result {
+            lock.lock()
+            defer { lock.unlock() }
+            return body(&storage)
+        }
+    }
+
+    func testEmitsInSubmissionOrderWhenWorkersFinishOutOfOrder() async throws {
+        let emitted = LockedBox([Int]())
+        // Earlier inputs sleep longest, so completion order is the exact
+        // reverse of submission order.
+        let renderer = OrderedConcurrentRenderer<Int, Int>(
+            concurrency: 4,
+            render: { input in
+                try await Task.sleep(nanoseconds: UInt64(4 - input) * 30_000_000)
+                return input
+            },
+            emit: { output in
+                emitted.withLock { $0.append(output) }
+            }
+        )
+
+        for input in 0..<4 {
+            try await renderer.submit(input)
+        }
+        try await renderer.finish()
+
+        XCTAssertEqual(
+            emitted.withLock { $0 },
+            [0, 1, 2, 3],
+            "Frames must be appended in presentation order, not completion order."
+        )
+    }
+
+    func testRendersConcurrentlyWithoutExceedingTheConcurrencyCap() async throws {
+        struct Activity { var current = 0; var peak = 0 }
+        let concurrency = 3
+        let activity = LockedBox(Activity())
+
+        let renderer = OrderedConcurrentRenderer<Int, Int>(
+            concurrency: concurrency,
+            render: { input in
+                activity.withLock {
+                    $0.current += 1
+                    $0.peak = max($0.peak, $0.current)
+                }
+                try await Task.sleep(nanoseconds: 50_000_000)
+                activity.withLock { $0.current -= 1 }
+                return input
+            },
+            emit: { _ in }
+        )
+
+        for input in 0..<9 {
+            try await renderer.submit(input)
+        }
+        try await renderer.finish()
+
+        let peak = activity.withLock { $0.peak }
+        XCTAssertGreaterThan(
+            peak,
+            1,
+            "Frames must composite in parallel; one at a time wastes every other core."
+        )
+        XCTAssertLessThanOrEqual(
+            peak,
+            concurrency,
+            "Each in-flight frame holds a full-size pixel buffer, so the cap must hold."
+        )
+    }
+
+    func testSurfacesARenderFailureInsteadOfTruncatingTheOutput() async {
+        struct RenderFailure: Error {}
+
+        let renderer = OrderedConcurrentRenderer<Int, Int>(
+            concurrency: 2,
+            render: { input in
+                if input == 0 { throw RenderFailure() }
+                try await Task.sleep(nanoseconds: 20_000_000)
+                return input
+            },
+            emit: { _ in }
+        )
+
+        do {
+            for input in 0..<6 {
+                try await renderer.submit(input)
+            }
+            try await renderer.finish()
+            XCTFail("A failed frame must throw, not end the movie early and silently.")
+        } catch is RenderFailure {
+            // Expected: the failure reaches the caller.
+        } catch {
+            XCTFail("Expected RenderFailure, got \(error).")
+        }
+    }
+}

--- a/ScreendropTests/PrefetchQueueTests.swift
+++ b/ScreendropTests/PrefetchQueueTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+/// `pumpVideo` decodes the next source frame inline, in the same loop that
+/// composites the current one, so decoding and drawing never overlap. The
+/// prefetch queue moves the blocking producer onto its own task while
+/// keeping delivery order and bounding how many frames sit in flight.
+final class PrefetchQueueTests: XCTestCase {
+    /// Minimal synchronized box. The producer closure runs off the test's
+    /// actor, so its state cannot be plain captured `var`s.
+    private final class LockedBox<Value>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: Value
+
+        init(_ value: Value) { storage = value }
+
+        func withLock<Result>(_ body: (inout Value) -> Result) -> Result {
+            lock.lock()
+            defer { lock.unlock() }
+            return body(&storage)
+        }
+    }
+
+    func testDeliversEveryElementInProductionOrderThenEndsTheStream() async {
+        let remaining = LockedBox([1, 2, 3, 4, 5])
+        let queue = PrefetchQueue<Int>(capacity: 2) {
+            remaining.withLock { $0.isEmpty ? nil : $0.removeFirst() }
+        }
+
+        var received: [Int] = []
+        while let value = await queue.next() {
+            received.append(value)
+        }
+
+        XCTAssertEqual(
+            received,
+            [1, 2, 3, 4, 5],
+            "Frames must reach the compositor in decode order, with no gaps."
+        )
+    }
+
+    func testDecodesAheadOfTheConsumerUpToCapacity() async throws {
+        let capacity = 3
+        let produced = LockedBox(0)
+        let queue = PrefetchQueue<Int>(capacity: capacity) {
+            produced.withLock { count in
+                guard count < 10 else { return nil }
+                count += 1
+                return count
+            }
+        }
+
+        // Take one frame, then leave the consumer idle. A queue that only
+        // decodes on demand stops at one; a prefetching one fills its buffer.
+        _ = await queue.next()
+
+        let target = capacity + 1
+        let deadline = Date().addingTimeInterval(5)
+        while produced.withLock({ $0 }) < target, Date() < deadline {
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        XCTAssertGreaterThanOrEqual(
+            produced.withLock { $0 },
+            target,
+            "The producer must decode ahead while the consumer is busy."
+        )
+    }
+
+    func testStopsProducingOnceCapacityIsBuffered() async throws {
+        let capacity = 2
+        let produced = LockedBox(0)
+        let queue = PrefetchQueue<Int>(capacity: capacity) {
+            produced.withLock { count in
+                guard count < 20 else { return nil }
+                count += 1
+                return count
+            }
+        }
+        defer { queue.cancel() }
+
+        // Nothing is consumed, so nothing can leave the buffer. An
+        // unbounded producer would run the source dry; a bounded one parks
+        // at exactly `capacity`.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(
+            produced.withLock { $0 },
+            capacity,
+            "Decoded frames are full-size pixel buffers, so the queue must stop at capacity."
+        )
+    }
+}

--- a/ScreendropTests/ResourcePoolTests.swift
+++ b/ScreendropTests/ResourcePoolTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+/// Compositors carry caches that are not thread-safe, so parallel frame
+/// workers each need their own. They are too expensive to build per frame -
+/// a cold compositor re-decodes the pointer artwork - so a fixed set is
+/// built once and lent out.
+final class ResourcePoolTests: XCTestCase {
+    private final class Worker {}
+
+    func testNeverLendsOneResourceToTwoBorrowersAtOnce() {
+        let pool = ResourcePool([Worker(), Worker()])
+
+        let first = pool.borrow()
+        let second = pool.borrow()
+
+        XCTAssertNotNil(first)
+        XCTAssertNotNil(second)
+        XCTAssertFalse(
+            first === second,
+            "Two frame workers sharing one compositor would race on its caches."
+        )
+    }
+
+    func testReportsExhaustionRatherThanLendingBeyondItsSize() {
+        let pool = ResourcePool([Worker()])
+
+        _ = pool.borrow()
+
+        XCTAssertNil(
+            pool.borrow(),
+            "An exhausted pool must say so, so the caller fails loudly."
+        )
+    }
+
+    func testLendsAResourceAgainOnceItIsReturned() {
+        let only = Worker()
+        let pool = ResourcePool([only])
+
+        guard let borrowed = pool.borrow() else {
+            return XCTFail("The pool lent nothing on its first borrow.")
+        }
+        pool.giveBack(borrowed)
+
+        XCTAssertTrue(
+            pool.borrow() === only,
+            "A returned worker must go back into circulation."
+        )
+    }
+}

--- a/ScreendropTests/StudioSourceImageCacheTests.swift
+++ b/ScreendropTests/StudioSourceImageCacheTests.swift
@@ -1,0 +1,57 @@
+import CoreGraphics
+import CoreVideo
+import XCTest
+
+/// The studio exporter renders on a fixed 60 fps output clock, but a screen
+/// capture only produces frames where pixels changed. Many consecutive output
+/// frames therefore share one source buffer, and rebuilding a full-size
+/// `CGImage` for each of them is pure waste.
+final class StudioSourceImageCacheTests: XCTestCase {
+    private func makePixelBuffer(width: Int = 8, height: Int = 4) -> CVPixelBuffer {
+        var buffer: CVPixelBuffer?
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            width,
+            height,
+            kCVPixelFormatType_32BGRA,
+            [
+                kCVPixelBufferCGImageCompatibilityKey: true,
+                kCVPixelBufferCGBitmapContextCompatibilityKey: true
+            ] as CFDictionary,
+            &buffer
+        )
+        XCTAssertEqual(status, kCVReturnSuccess)
+        return buffer!
+    }
+
+    func testReusesOneImageWhileTheSourceBufferIsUnchanged() {
+        let cache = StudioSourceImageCache(colorSpace: CGColorSpaceCreateDeviceRGB())
+        let buffer = makePixelBuffer()
+
+        guard let first = cache.image(for: buffer),
+              let second = cache.image(for: buffer) else {
+            return XCTFail("The cache produced no image for a valid pixel buffer.")
+        }
+
+        XCTAssertTrue(
+            first === second,
+            "Consecutive output frames sharing one source buffer must reuse one CGImage."
+        )
+    }
+
+    func testRebuildsTheImageWhenTheSourceBufferChanges() {
+        let cache = StudioSourceImageCache(colorSpace: CGColorSpaceCreateDeviceRGB())
+        let first = makePixelBuffer()
+        let second = makePixelBuffer()
+
+        guard let firstImage = cache.image(for: first),
+              let secondImage = cache.image(for: second) else {
+            return XCTFail("The cache produced no image for a valid pixel buffer.")
+        }
+
+        XCTAssertFalse(
+            firstImage === secondImage,
+            "A new source buffer must produce a new image, not the previous frame."
+        )
+    }
+}


### PR DESCRIPTION
Exporting a 5760x3240 @ 60 fps screen recording (7 min 44 s) through the recording studio took **hours**. Re-encoding the same source with `ffmpeg` on the same machine took minutes.

The encoder is not the problem — `AVAssetWriter` / VideoToolbox is fine. The cost is `StudioFrameCompositor.render`, which composites every output frame with CPU CoreGraphics at full source resolution, single-threaded.

Every change here is quality-neutral. No compression setting, resolution option, interpolation quality, or motion-blur sample count is touched. Output pixels are unchanged.

## Commits

**1. Cache the source image per source buffer** — The export renders on a fixed 60 fps clock, but a screen capture only emits frames where pixels changed, so consecutive ticks routinely share one source buffer. `render` rebuilt a full-size `CGImage` every frame regardless — a 74.6 MB snapshot at 5760x3240. Now cached on pixel-buffer identity.

**2. Overlap decoding with compositing** — `pumpVideo` called `copyNextSampleBuffer()` inline in the loop that composited the current frame, so decoding never overlapped with drawing. `PrefetchQueue` moves the blocking reader to its own thread with a three-frame look-ahead, bounded because each buffered frame is a full-size pixel buffer held out of the reader's pool.

**3. Composite frames in parallel** — The main change. Frame compositing is a pure function of its own timestamps, so it fans out across cores. Everything ordered stays on the driving task: the clip timeline walk, the source reader, and the camera feed (a sequential decoder that assumes rising source times). `OrderedConcurrentRenderer` keeps a FIFO of in-flight tasks — awaiting the oldest first gives the writer its appends in presentation order, and refusing to start past the cap bounds concurrency, both by construction. Concurrency is capped at four: two cores stay free for the decoder and encoder, and the cap bounds memory since each in-flight frame holds a full-size destination buffer.

## Test target

The project had none, so this adds one. It is an **unhosted logic bundle** that compiles the units under test directly, so the suite never launches the menu bar app — no hotkey registration, no Sparkle, no permission prompts. It runs in well under a second.

```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
  -project Screendrop.xcodeproj -scheme Screendrop \
  -configuration Debug -destination "platform=macOS"
```

11 tests, all passing. Every one was written before its implementation and watched fail first. Where an implementation already satisfied a newly added test, the implementation was deliberately mutated to confirm the test caught the regression, then restored.

## What is verified, and what is not

Verified: the units above, and that the app target builds clean with no new warnings.

**Not verified: an actual end-to-end export.** I have no signing certificate for this project, so I could not run the app and export a real recording. The claim that output is unchanged rests on reasoning — the same compositor code draws the same frames from the same inputs — not on a byte comparison of two exported files. Please run one export before and after and diff the results.

The measured speed-up is therefore also unverified. The reasoning predicts roughly 4x from parallelism, plus whatever the removed per-frame snapshot and the decode overlap contribute.

## Also worth knowing

`VideoCompressionSpeed` (Ultrafast/Fast/Medium/Slow) has no call sites anywhere in the Swift target. Neither do `VideoCompressionQuality.crf`, `.audioBitrate`, `VideoCompressionCodec.encoder`, or `VideoCompressionResolution.scaleFilter` — all left over from the ffmpeg era. The speed picker in the export UI currently does nothing. Not touched here, but it misleads anyone trying to make a slow export faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1yJxCvWsv7TVv9XneRhwp