### PR TITLE
feat: allow pressing space to switch to window mode during area capture

### DIFF
--- a/Screendrop/CaptureCoordinator.swift
+++ b/Screendrop/CaptureCoordinator.swift
@@ -111,6 +111,7 @@ final class CaptureCoordinator {
         // The self-timer is handled by screencapture's `-T` so the delay
         // happens *after* the area is drawn, not before.
         guard let url = await ScreenshotManager.shared.captureArea(
+            includeShadow: ScreendropPreferences.captureWindowShadow,
             delaySeconds: ScreendropPreferences.captureDelaySeconds
         ) else { return nil }
         let displayID = ActiveDisplayResolver.activeDisplayID(preferPointer: true)

--- a/Screendrop/ScreenshotManager.swift
+++ b/Screendrop/ScreenshotManager.swift
@@ -72,10 +72,16 @@ final class ScreenshotManager {
     // MARK: - Area Capture
     
     /// Uses the native macOS screencapture tool for interactive area drag selection.
-    /// `-s` = drag to select area, `-t png` = lossless PNG. `delaySeconds` maps
-    /// to `-T`, firing after the area has been drawn.
-    func captureArea(delaySeconds: Int = 0) async -> URL? {
-        return await runScreencapture(args: ["-s"] + delayArguments(delaySeconds))
+    /// `-i` = interactive mode (starts in area selection mode and supports pressing Space to switch to window selection),
+    /// `-o` = no shadow, `-t png` = lossless PNG. `delaySeconds` maps
+    /// to `-T`, firing after the area/window has been chosen.
+    func captureArea(includeShadow: Bool = false, delaySeconds: Int = 0) async -> URL? {
+        var args = ["-i"]
+        if !includeShadow {
+            args.append("-o")
+        }
+        args.append(contentsOf: delayArguments(delaySeconds))
+        return await runScreencapture(args: args)
     }
 
     /// Builds the `-T <seconds>` delay arguments, or none when the timer is off.


### PR DESCRIPTION
## Resolves issue #33

Uses macOS's interactive mode (`-i`) instead of selection-only (`-s`) in `ScreenshotManager.captureArea`, enabling users to press `Space` to switch between area drag selection and window selection mode. Also passes down `captureWindowShadow` preferences to ensure window captures respect shadow settings when toggled via Space.