### PR TITLE
Pin screenshots: adjust opacity by scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ New captures appear as floating cards on the active display. From a card you can
 - Save it to disk.
 - Create a smaller JPEG.
 - Pin a screenshot as an always-on-top reference.
+- Scroll over a pinned screenshot to adjust its opacity.
 - Open Quick Look.
 - Annotate a screenshot or edit a recording.
 - Upload to your cloud and copy the link.

--- a/Screendrop/PinnedScreenshotPresenter.swift
+++ b/Screendrop/PinnedScreenshotPresenter.swift
@@ -92,6 +92,24 @@ final class PinnedScreenshotPresenter {
 private final class PinnedPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    /// Scroll over a pin to fade it in/out. Handled at the window level so it
+    /// only fires when the cursor is over the pin, and applied via
+    /// `alphaValue` so the compositor blends the existing buffer without
+    /// re-rendering the SwiftUI image view.
+    override func scrollWheel(with event: NSEvent) {
+        // Ignore momentum coasting so a flick doesn't keep fading after release.
+        guard event.momentumPhase.isEmpty else { return }
+
+        // Trackpads report pixel deltas; discrete wheels report lines, which
+        // Apple docs say to scale by a line height for parity.
+        let rawDelta = event.scrollingDeltaY
+        guard rawDelta != 0 else { return }
+        let points = event.hasPreciseScrollingDeltas ? rawDelta : rawDelta * 20
+
+        let sensitivity: CGFloat = 0.002
+        alphaValue = min(1, max(0.2, alphaValue + points * sensitivity))
+    }
 }
 
 private struct PinnedScreenshotView: View {

--- a/Screendrop/PinnedScreenshotPresenter.swift
+++ b/Screendrop/PinnedScreenshotPresenter.swift
@@ -104,9 +104,12 @@ private final class PinnedPanel: NSPanel {
         // Trackpads report pixel deltas; discrete wheels report lines, which
         // Apple docs say to scale by a line height for parity.
         // https://developer.apple.com/documentation/appkit/nsevent/scrollingdeltay
+        // One line ≈ 40pt, matching Chromium's kScrollbarPixelsPerCocoaTick.
+        // https://codereview.chromium.org/2226933004/patch/160001/170001
+        // At 0.002 sensitivity that's 0.08/notch (~10 clicks, full range).
         let rawDelta = event.scrollingDeltaY
         guard rawDelta != 0 else { return }
-        let points = event.hasPreciseScrollingDeltas ? rawDelta : rawDelta * 20
+        let points = event.hasPreciseScrollingDeltas ? rawDelta : rawDelta * 40
 
         // `scrollingDeltaY` follows the user's Natural Scroll setting, so
         // un-invert it: physical scroll-up must always restore opacity.

--- a/Screendrop/PinnedScreenshotPresenter.swift
+++ b/Screendrop/PinnedScreenshotPresenter.swift
@@ -107,8 +107,12 @@ private final class PinnedPanel: NSPanel {
         guard rawDelta != 0 else { return }
         let points = event.hasPreciseScrollingDeltas ? rawDelta : rawDelta * 20
 
+        // `scrollingDeltaY` follows the user's Natural Scroll setting, so
+        // un-invert it: physical scroll-up must always restore opacity.
+        let physicalUp = event.isDirectionInvertedFromDevice ? -points : points
+
         let sensitivity: CGFloat = 0.002
-        alphaValue = min(1, max(0.2, alphaValue + points * sensitivity))
+        alphaValue = min(1, max(0.2, alphaValue + physicalUp * sensitivity))
     }
 }
 

--- a/Screendrop/PinnedScreenshotPresenter.swift
+++ b/Screendrop/PinnedScreenshotPresenter.swift
@@ -103,12 +103,14 @@ private final class PinnedPanel: NSPanel {
 
         // Trackpads report pixel deltas; discrete wheels report lines, which
         // Apple docs say to scale by a line height for parity.
+        // https://developer.apple.com/documentation/appkit/nsevent/scrollingdeltay
         let rawDelta = event.scrollingDeltaY
         guard rawDelta != 0 else { return }
         let points = event.hasPreciseScrollingDeltas ? rawDelta : rawDelta * 20
 
         // `scrollingDeltaY` follows the user's Natural Scroll setting, so
         // un-invert it: physical scroll-up must always restore opacity.
+        // https://developer.apple.com/documentation/appkit/nsevent/isdirectioninvertedfromdevice
         let physicalUp = event.isDirectionInvertedFromDevice ? -points : points
 
         let sensitivity: CGFloat = 0.002


### PR DESCRIPTION
## What

Pinned screenshots can now be faded in/out by scrolling over them: scroll up to restore full opacity, scroll down to fade toward translucent.

## How

All in `Screendrop/PinnedScreenshotPresenter.swift`, as a `scrollWheel(with:)` override on `PinnedPanel`:

- **Window-level handling** — fires only when the cursor is over the pin (no hover tracking needed), no global event monitor, nothing scrollable inside to forward to.
- **Compositor-level opacity** — writes to `panel.alphaValue` instead of SwiftUI `@State`/`.opacity()`, so the WindowServer blends the existing buffer with no view re-render at 60–120Hz trackpad event rates.
- **Direction normalized** — `scrollingDeltaY` follows the Natural Scroll setting, so it's un-inverted via `isDirectionInvertedFromDevice`: physical scroll-up always restores opacity ([docs](https://developer.apple.com/documentation/appkit/nsevent/isdirectioninvertedfromdevice)).
- **Discrete wheels scaled ×40** — Apple prescribes scaling lines by a line height ([docs](https://developer.apple.com/documentation/appkit/nsevent/scrollingdeltay)); 40pt matches Chromium's `kScrollbarPixelsPerCocoaTick`. At 0.002 sensitivity that's 0.08/notch (~10 clicks, full range). Trackpad unchanged (~400pt, full range).
- **Clamped to 0.2…1.0** so a pin can't go invisible/ungrabbable; momentum-phase events ignored so a flick doesn't keep fading after release.

## Commits

- Add scroll-to-adjust opacity on pinned screenshots
- Fix pin scroll direction so scroll-up restores opacity
- Add Apple docs links to pin scroll comments
- Use 40pt line step for discrete wheels, matching Chromium

## Testing

- Built `Screendrop Dev` scheme (`BUILD SUCCEEDED`; plain-scheme build fails only on the pre-existing missing Mac Development signing cert on this machine).
- Ran the Dev build alongside production and verified trackpad scroll direction/speed live. No wheel mouse available — discrete-wheel step is reasoned from Chromium/WebKit precedent, not empirically tested.

Made with [Cursor](https://cursor.com)

## Related work

Complementary to #24 (keyboard opacity controls for pinned screenshots): that PR maps number keys to opacity steps on focused pins, while this one adds pointer scroll-to-fade. Both can coexist; if both merge there may be a small textual overlap in `PinnedScreenshotPresenter.swift`.

